### PR TITLE
default layout: html `lang` attribute should allow user customization

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ page.lang | default: site.lang | default: "en" }}">
 
   {% include head.html %}
 


### PR DESCRIPTION
Ported over from https://github.com/jekyll/jekyll/pull/4967 at the request of @parkr. :)