### PR TITLE
include _layouts, _includes, and _sass dir in gem

### DIFF
--- a/minima.gemspec
+++ b/minima.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["plugin_type"] = "theme"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(exe|_layouts|_includes|_sass)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(exe)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
 


### PR DESCRIPTION
fixes jekyll/jekyll#5145.

before:
![screen shot 2016-07-28 at 12 06 36](https://cloud.githubusercontent.com/assets/570608/17209138/caf3b192-54bb-11e6-908c-c2319b1e01dd.png)
