### PR TITLE
Use upstream gemspec file matcher

### DIFF
--- a/minima.gemspec
+++ b/minima.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["plugin_type"] = "theme"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(exe)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(<%= theme_directories.join("|") %>|LICENSE|README)/i}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
 

--- a/minima.gemspec
+++ b/minima.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["plugin_type"] = "theme"
 
-  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(<%= theme_directories.join("|") %>|LICENSE|README)/i}) }
+  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(_includes|_layouts|_sass|LICENSE|README)/i}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
 


### PR DESCRIPTION
This PR adopts the core template's gemspec file matcher, as fixed in https://github.com/jekyll/jekyll/pull/5152.