### PR TITLE
Add support to Disqus

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,23 @@ And then execute:
 
     $ bundle
 
+## Enabling comments (via Disqus)
+
+Optionally, if you have a Disqus account, you can tell Jekyll to use it to show a comments section below each post.
+
+To enable it, add the following lines to your Jekyll site:
+
+```yaml
+  disqus:
+    shortname: my_disqus_shortname
+```
+
+You can find out more about Disqus' shortnames [here](https://help.disqus.com/customer/portal/articles/466208).
+
+Comments are enabled by default and will only appear in production, i.e., `JEKYLL_ENV=production`
+
+If you don't want to display comments for a particular post you can disable them by adding `comments: false` to that post's YAML Front Matter.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/jekyll/minima. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/_includes/disqus_comments.html
+++ b/_includes/disqus_comments.html
@@ -1,0 +1,19 @@
+{% if page.comments %}
+  <div id="disqus_thread"></div>
+  <script>
+    var disqus_config = function () {
+      this.page.url = '{{ site.url }}{{ page.url }}';        // Replace PAGE_URL with your page's canonical URL variable
+      this.page.identifier = '{{ site.url }}{{ page.url }}'; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
+    };
+
+    (function() {  // DON'T EDIT BELOW THIS LINE
+      var d = document, s = d.createElement('script');
+
+      s.src = '//{{ site.disqus.shortname }}.disqus.com/embed.js';
+
+      s.setAttribute('data-timestamp', +new Date());
+      (d.head || d.body).appendChild(s);
+    })();
+  </script>
+  <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
+{% endif %}

--- a/_includes/disqus_comments.html
+++ b/_includes/disqus_comments.html
@@ -2,11 +2,11 @@
   <div id="disqus_thread"></div>
   <script>
     var disqus_config = function () {
-      this.page.url = '{{ site.url }}{{ page.url }}';        // Replace PAGE_URL with your page's canonical URL variable
-      this.page.identifier = '{{ site.url }}{{ page.url }}'; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
+      this.page.url = '{{ site.url }}{{ page.url }}';
+      this.page.identifier = '{{ site.url }}{{ page.url }}';
     };
 
-    (function() {  // DON'T EDIT BELOW THIS LINE
+    (function() {
       var d = document, s = d.createElement('script');
 
       s.src = '//{{ site.disqus.shortname }}.disqus.com/embed.js';

--- a/_includes/disqus_comments.html
+++ b/_includes/disqus_comments.html
@@ -1,9 +1,15 @@
 {% if page.comments and jekyll.environment == "production" %}
+  {% if site.url %}
+    {% assign disqus_url = page.url | prepend: site.url %}
+  {% elsif site.github.url %}
+    {% assign disqus_url = page.url | prepend: site.github.url %}
+  {% endif %}
+
   <div id="disqus_thread"></div>
   <script>
     var disqus_config = function () {
-      this.page.url = '{{ site.url }}{{ page.url }}';
-      this.page.identifier = '{{ site.url }}{{ page.url }}';
+      this.page.url = '{{ disqus_url }}';
+      this.page.identifier = '{{ disqus_url }}';
     };
 
     (function() {

--- a/_includes/disqus_comments.html
+++ b/_includes/disqus_comments.html
@@ -9,7 +9,7 @@
     (function() {
       var d = document, s = d.createElement('script');
 
-      s.src = '//{{ site.disqus.shortname }}.disqus.com/embed.js';
+      s.src = 'https://{{ site.disqus.shortname }}.disqus.com/embed.js';
 
       s.setAttribute('data-timestamp', +new Date());
       (d.head || d.body).appendChild(s);

--- a/_includes/disqus_comments.html
+++ b/_includes/disqus_comments.html
@@ -1,4 +1,4 @@
-{% if page.comments and jekyll.environment == "production" %}
+{% if page.comments != false and jekyll.environment == "production" %}
   {% if site.url %}
     {% assign disqus_url = page.url | prepend: site.url %}
   {% elsif site.github.url %}

--- a/_includes/disqus_comments.html
+++ b/_includes/disqus_comments.html
@@ -1,4 +1,4 @@
-{% if page.comments %}
+{% if page.comments and jekyll.environment == "production" %}
   <div id="disqus_thread"></div>
   <script>
     var disqus_config = function () {

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,4 +12,7 @@ layout: default
     {{ content }}
   </div>
 
+  {% if site.disqus.shortname %}
+    {% include disqus_comments.html %}
+  {% endif %}
 </article>


### PR DESCRIPTION
This PR enables the user to show, optionally, Disqus comments below each post.

In order to get this working the user only needs to add the following to `_config.yml`:

```yaml
disqus:
  shortname: my_disqus_shortname
```

You can find out more about Disqus' shortnames [here](https://help.disqus.com/customer/portal/articles/466208).

The current behavior remains the same if no `disqus` property is supplied.