### PR TITLE
Added "author" in footer instead of double title

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,7 +7,13 @@
     <div class="footer-col-wrapper">
       <div class="footer-col footer-col-1">
         <ul class="contact-list">
-          <li>{{ site.title | escape }}</li>
+          <li>
+            {% if site.author %}
+              {{ site.author | escape }}
+            {% else %}
+              {{ site.title | escape }}
+            {% endif %}
+            </li>
           <li><a href="mailto:{{ site.email }}">{{ site.email }}</a></li>
         </ul>
       </div>

--- a/example/_config.yml
+++ b/example/_config.yml
@@ -1,6 +1,7 @@
 theme: minima
 
 name: A site title
+author: Mr. GitHub User
 description: "Write an awesome description for your new site here. It will appear in your document head meta (for Google search results) and in your feed.xml site description."
 
 collections:


### PR DESCRIPTION
I wrote this PR because I thought that having site.title shown twice in the footer was redundant, so I introduced the "author" variable in _config.yml to be shown just above the email address. Moreover, this behavior is optional, since if you don't define the "author" variable it falls back to the "title" variable.