### PR TITLE
Look for site.github.url if it exists

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,7 +6,9 @@
   <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
   <meta name="description" content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}">
 
-  <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
-  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-  <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
+  {% assign custom_url = site.url | append: site.baseurl %}
+  {% assign full_base_url = site.github.url | default: custom_url %}
+  <link rel="stylesheet" href="{{ "/css/main.css" | prepend: full_base_url }}">
+  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: full_base_url }}">
+  <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | prepend: full_base_url }}">
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,9 @@
 
   <div class="wrapper">
 
-    <a class="site-title" href="{{ site.baseurl }}/">{{ site.title | escape }}</a>
+    {% assign custom_url = site.url | append: site.baseurl %}
+    {% assign full_base_url = site.github.url | default: custom_url %}
+    <a class="site-title" href="{{ full_base_url }}/">{{ site.title | escape }}</a>
 
     <nav class="site-nav">
       <a href="#" class="menu-icon">
@@ -16,7 +18,7 @@
       <div class="trigger">
         {% for my_page in site.pages %}
           {% if my_page.title %}
-          <a class="page-link" href="{{ my_page.url | prepend: site.baseurl }}">{{ my_page.title | escape }}</a>
+          <a class="page-link" href="{{ my_page.url | prepend: full_base_url }}">{{ my_page.title | escape }}</a>
           {% endif %}
         {% endfor %}
       </div>

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 3.2"
+gem "minima", path: "../"

--- a/example/_config.yml
+++ b/example/_config.yml
@@ -1,11 +1,17 @@
-theme: minima
 title: Your awesome title
-email: your-email@domain.com
 author: Mr. GitHub User
-description: "Write an awesome description for your new site here. It will appear in your document head meta (for Google search results) and in your feed.xml site description."
+email: your-email@domain.com
+description: > # this means to ignore newlines until "baseurl:"
+  Write an awesome description for your new site here. You can edit this
+  line in _config.yml. It will appear in your document head meta (for
+  Google search results) and in your feed.xml site description.
+baseurl: "/minima"
 twitter_username: jekyllrb
 github_username:  jekyll
 
-collections:
-  posts:
-    permalink: /posts/:title
+# Build settings
+markdown: kramdown
+theme: minima
+exclude:
+  - Gemfile
+  - Gemfile.lock

--- a/example/index.html
+++ b/example/index.html
@@ -1,10 +1,13 @@
 ---
-layout: default
+layout: page
 ---
 
 <div class="home">
 
   <h1 class="page-heading">Posts</h1>
+
+  {% assign custom_url = site.url | append: site.baseurl %}
+  {% assign full_base_url = site.github.url | default: custom_url %}
 
   <ul class="post-list">
     {% for post in site.posts %}
@@ -12,12 +15,12 @@ layout: default
         <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }}</span>
 
         <h2>
-          <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title | escape }}</a>
+          <a class="post-link" href="{{ post.url | prepend: full_base_url }}">{{ post.title | escape }}</a>
         </h2>
       </li>
     {% endfor %}
   </ul>
 
-  <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p>
+  <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: full_base_url }}">via RSS</a></p>
 
 </div>


### PR DESCRIPTION
This fixes #17. /cc @benbalter

This requires a change in the `jekyll new` template, sadly, namely in the listing of `site.posts`. We could potentially ship an `include` for `posts_list` or something so we don't have to update it in Jekyll in the future?