### PR TITLE
priority to site.url when site.github.url is available

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,7 @@
   <div class="wrapper">
 
     {% assign custom_url = site.url | append: site.baseurl %}
-    {% assign full_base_url = site.github.url | default: custom_url %}
+    {% assign full_base_url = custom_url | default: site.github.url %}
     <a class="site-title" href="{{ full_base_url }}/">{{ site.title | escape }}</a>
 
     <nav class="site-nav">

--- a/example/index.html
+++ b/example/index.html
@@ -7,7 +7,7 @@ layout: page
   <h1 class="page-heading">Posts</h1>
 
   {% assign custom_url = site.url | append: site.baseurl %}
-  {% assign full_base_url = site.github.url | default: custom_url %}
+  {% assign full_base_url = custom_url | default: site.github.url %}
 
   <ul class="post-list">
     {% for post in site.posts %}


### PR DESCRIPTION
# Issue:
* When using github-pages gem and creating a site with the command `bundle exec jekyll new . -force`, there is inconstancies in the url links after build.
* even if site.url or site.baseurl are set, the site.github.url was used in the header.html snippet
* when running the site locally there are link to github.com instead of local jekyll server IP

# Solution suggested:
* The patch is consistent with the previous commit: addf9a3787ef079fd26b8fd54d160f0cb684e57f
* The patch allows to generate only local links when using `bundle exec jekyll serve`
