### PR TITLE
Update gem regex to include new `assets` directory

### DIFF
--- a/minima.gemspec
+++ b/minima.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.metadata["plugin_type"] = "theme"
 
   spec.files         = `git ls-files -z`.split("\x0").select do |f|
-    f.match(%r{^(_(includes|layouts|sass)/|(LICENSE|README)((\.(txt|md|markdown)|$)))}i)
+    f.match(%r{^(assets|_(includes|layouts|sass)/|(LICENSE|README)((\.(txt|md|markdown)|$)))}i)
   end
 
   spec.bindir        = "exe"


### PR DESCRIPTION
Update the regex in `minima.gemspec` to include `assets` directory in **Minima-2.0** gem.
Should've covered this in #43, my bad.. 

--
/cc @benbalter, @parkr