### PR TITLE
Update gemspec to require at least Jekyll 3.3

### DIFF
--- a/minima.gemspec
+++ b/minima.gemspec
@@ -35,7 +35,8 @@ https://github.com/jekyll/minima#customization
 
 msg
 
-  spec.add_development_dependency "jekyll", "~> 3.2"
+  spec.add_runtime_dependency "jekyll", "~> 3.3"
+
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
replacing `development_dependency` with `runtime_dependency` to require ~> Jekyll 3.3