### PR TITLE
Remove incomplete status from spec summary

### DIFF
--- a/minima.gemspec
+++ b/minima.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Joel Glovier"]
   spec.email         = ["jglovier@github.com"]
 
-  spec.summary       = %q{A beautiful, minimal theme for Jekyll. NOT DONE YET.}
+  spec.summary       = %q{A beautiful, minimal theme for Jekyll.}
   spec.homepage      = "https://github.com/jekyll/minima"
   spec.license       = "MIT"
 


### PR DESCRIPTION
Being shipped with Jekyll (checked on `3.3.0`).
