### PR TITLE
modify Rakefile to watch assets folder as well

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -47,6 +47,7 @@ task :preview do
     base.join("_includes"),
     base.join("_layouts"),
     base.join("_sass"),
+    base.join("assets"),
     options["source"],
     :ignore => listen_ignore_paths(base, options),
     :force_polling => options['force_polling'],


### PR DESCRIPTION
This pull modifies the `Rakefile` to have the `assets` dir _watched_ during **development**

/cc @jekyll/minima 