### PR TITLE
Remove 2.0 post-install message

### DIFF
--- a/minima.gemspec
+++ b/minima.gemspec
@@ -19,22 +19,6 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
-  spec.post_install_message = <<-msg
-
-----------------------------------------------
-Thank you for installing minima 2.0!
-
-Minima 2.0 comes with a breaking change that
-renders '<your-site>/css/main.scss' redundant.
-That file is now bundled with this gem as
-'<minima>/assets/main.scss'.
-
-More Information:
-https://github.com/jekyll/minima#customization
-----------------------------------------------
-
-msg
-
   spec.add_runtime_dependency "jekyll", "~> 3.3"
 
   spec.add_development_dependency "bundler", "~> 1.12"


### PR DESCRIPTION
Now that 2.1.0 is out, I figured this wasn't appropriate anymore