### PR TITLE
option to anonymize IP in Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ theme: minima
 And then execute:
 
     $ bundle
-    
+
 
 ## Usage
 
@@ -67,13 +67,17 @@ If you don't want to display comments for a particular post you can disable them
 
 ### Enabling Google Analytics
 
-To enable Google Anaytics, add the following lines to your Jekyll site:
+To enable Google Anaytics tracking, add or uncomment the following lines in your `_config.yml` and copy-paste your own tracking id:
 
 ```yaml
-  google_analytics: UA-NNNNNNNN-N
+  google_analytics:
+    tracking_id: UA-NNNNNNNN-N
+    anonymize_ip: false
 ```
 
-Google Analytics will only appear in production, i.e., `JEKYLL_ENV=production`
+Optionnally, to comply with your country own privacy policies, just set `anonymize_ip` to `true`.
+
+Google Analytics will only be active in productionn, i.e. when `JEKYLL_ENV=production`.
 
 ## Contributing
 

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -4,8 +4,10 @@
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-  ga('create', '{{ site.google_analytics }}', 'auto');
+  ga('create', '{{ site.google_analytics.tracking_id }}', 'auto');
+  {% if site.google_analytics.anonymize_ip == true %}
+    ga('set', 'anonymizeIp', true);
+  {% endif %}
   ga('send', 'pageview');
 
 </script>
-  

--- a/example/_config.yml
+++ b/example/_config.yml
@@ -9,9 +9,19 @@ baseurl: "/minima"
 twitter_username: jekyllrb
 github_username:  jekyll
 
+
 # Build settings
 markdown: kramdown
 theme: minima
+
+# theme settings
+# disqus:
+#   shortname: my_disqus_shortname
+# google_analytics:
+#   tracking_id: UA-NNNNNNNN-N
+#   anonymize_ip: false
+
+
 exclude:
   - Gemfile
   - Gemfile.lock


### PR DESCRIPTION
Fix #83 

This PR just want to provide an easy way to allow site owners to disable IP tracking by Google, as it is requested in somes countries.

/cc @jekyll/minima 