### PR TITLE
Provide a hook for theme users to inject custom CSS

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,9 +7,10 @@
   <meta name="description" content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}">
 
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
+  <link rel="stylesheet" href="{{ "/assets/custom.css" | relative_url }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | relative_url }}">
-  
+
   {% if jekyll.environment == 'production' and site.google_analytics %}
   {% include google-analytics.html %}
   {% endif %}

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -1,0 +1,1 @@
+/* Intentionally left empty */


### PR DESCRIPTION
There is currently no easy way for users to override CSS rules defined by minima's main.css. In order to do this, one has to copy _includes/head.html to the user project for adding an additional stylesheet entry below the main.css.

This PR adds an empty custom.css and corresponding stylesheet declaration to minima. This way users can simply add assets/custom.css to their project if they need to override/add css rules.