### PR TITLE
handling content outside of posts

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -4,10 +4,10 @@ layout: default
 
 <div class="home">
 
-  <h1 class="page-heading">Posts</h1>
-  
   {{ content }}
 
+  <h1 class="page-heading">Posts</h1>
+  
   <ul class="post-list">
     {% for post in site.posts %}
       <li>


### PR DESCRIPTION
it doesn't make a lot of sense to pull content from `layout: home` pages under the *Posts* heading. instead, this content should be included before the *Posts* section.