### PR TITLE
Change discuss script URL pattern

### DIFF
--- a/_includes/disqus_comments.html
+++ b/_includes/disqus_comments.html
@@ -10,7 +10,7 @@
     (function() {
       var d = document, s = d.createElement('script');
 
-      s.src = 'https://{{ site.disqus.shortname }}.disqus.com/embed.js';
+      s.src = '//{{ site.disqus.shortname }}.disqus.com/embed.js';
 
       s.setAttribute('data-timestamp', +new Date());
       (d.head || d.body).appendChild(s);


### PR DESCRIPTION
For some reason when URL for Disqus script starts from 'https://' comments are
not shown. I changed it to start from '//' like [instructions](https://disqus.com/admin/install/platforms/universalcode)
say and now it works fine. Not sure what was the problem, but maybe this change
will help someone else.