### PR TITLE
Replace `twitter_username` with `twitter:username`

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -28,9 +28,9 @@
           </li>
           {% endif %}
 
-          {% if site.twitter_username %}
+          {% if site.twitter.username %}
           <li>
-            {% include icon-twitter.html username=site.twitter_username %}
+            {% include icon-twitter.html username=site.twitter.username %}
           </li>
           {% endif %}
         </ul>

--- a/example/_config.yml
+++ b/example/_config.yml
@@ -6,7 +6,9 @@ description: > # this means to ignore newlines until "baseurl:"
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
 baseurl: "/minima"
-twitter_username: jekyllrb
+twitter:
+  username: jekyllrb
+
 github_username:  jekyll
 
 # Build settings


### PR DESCRIPTION
The `jekyll-seo-tag` plugin already defines a format where it expects to
find the twitter username.

This replaces all occurences of `twitter_username` with
`twitter:username` to match that expectation.