### PR TITLE
Include jekyll-seo-tag when present

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,4 +13,8 @@
   {% if jekyll.environment == 'production' and site.google_analytics %}
   {% include google-analytics.html %}
   {% endif %}
+
+  {% if site.gems contains 'jekyll-seo-tag' %}
+  {% include seo.html %}
+  {% endif %}
 </head>

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -1,0 +1,1 @@
+{% seo title=false %}


### PR DESCRIPTION
This checks for the inclusion of `jekyll-seo-tag` via site.gems and
includes it in head.html when available making integration with the
jekyll-seo-tag plugin seamless.