### PR TITLE
More easily customizable CSS

### DIFF
--- a/_sass/minima.scss
+++ b/_sass/minima.scss
@@ -1,3 +1,5 @@
+@charset "utf-8";
+
 // Define defaults for each variable.
 
 $base-font-family: "Helvetica Neue", Helvetica, Arial, sans-serif !default;

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,39 +1,5 @@
 ---
 # Only the main Sass file needs front matter (the dashes are enough)
 ---
-@charset "utf-8";
 
-// Our variables
-$base-font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-$base-font-size:   16px;
-$base-font-weight: 400;
-$small-font-size:  $base-font-size * 0.875;
-$base-line-height: 1.5;
-
-$spacing-unit:     30px;
-
-$text-color:       #111;
-$background-color: #fdfdfd;
-$brand-color:      #2a7ae2;
-
-$grey-color:       #828282;
-$grey-color-light: lighten($grey-color, 40%);
-$grey-color-dark:  darken($grey-color, 25%);
-
-// Width of the content area
-$content-width:    800px;
-
-$on-palm:          600px;
-$on-laptop:        800px;
-
-// Minima also includes a mixin for defining media queries.
-// Use media queries like this:
-// @include media-query($on-palm) {
-//     .wrapper {
-//         padding-right: $spacing-unit / 2;
-//         padding-left: $spacing-unit / 2;
-//     }
-// }
-
-// Import partials from the `minima` theme.
 @import "minima";


### PR DESCRIPTION
This is an alternate approach to https://github.com/jekyll/minima/pull/86 which mirrors the approach we take on all the https://github.com/pages-themes themes.

The idea being, the default CSS file includes only an @import statement with the themes name, and all defaults and imports exist in the `_sass` directory.

That way a novice user can simply copy the `assets/style.scss` file (or write the one line themself) and add any custom css after the import statement.

The variable defaults already exist in `_sass/minima.scss` and are duplicative (and confusing/overly complex IMHO).