### PR TITLE
Change RSS references

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,7 +8,9 @@
 
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
-  <link rel="alternate" type="application/atom+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | relative_url }}">
+  {% if site.gems contains "jekyll-feed" %}
+    <link rel="alternate" type="application/atom+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | relative_url }}">
+  {% endif %}
   
   {% if jekyll.environment == 'production' and site.google_analytics %}
   {% include google-analytics.html %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,7 +8,7 @@
 
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
-  <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | relative_url }}">
+  <link rel="alternate" type="application/atom+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | relative_url }}">
   
   {% if jekyll.environment == 'production' and site.google_analytics %}
   {% include google-analytics.html %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -21,6 +21,6 @@ layout: default
     {% endfor %}
   </ul>
 
-  <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | relative_url }}">via RSS</a></p>
+  <p class="rss-subscribe"><a href="{{ "/feed.xml" | relative_url }}">Subscribe</a></p>
 
 </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -20,7 +20,7 @@ layout: default
       </li>
     {% endfor %}
   </ul>
-
-  <p class="rss-subscribe"><a href="{{ "/feed.xml" | relative_url }}">Subscribe</a></p>
-
+  {% if site.gems contains "jekyll-feed" %}
+    <p class="rss-subscribe"><a href="{{ "/feed.xml" | relative_url }}">Subscribe</a></p>
+  {% endif %}
 </div>


### PR DESCRIPTION
The jekyll-feed plugin uses Atom not RSS.

But I've removed the format completely as I don't think people care. I also fixed the mime type, which should help with some parsing issues.