### PR TITLE
Increase flexibility of 'home' layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Minima has been scaffolded by the `jekyll new-theme` command and therefore has a
 Refers to files within the `_layouts` directory, that define the markup for your theme.
 
   - `default.html` &mdash; The base layout that lays the foundation for subsequent layouts. The derived layouts inject their contents into this file at the line that says ` {{ content }} ` and are linked to this file via [FrontMatter](https://jekyllrb.com/docs/frontmatter/) declaration `layout: default`.
-  - `home.html` &mdash; The layout for your landing-page / home-page / index-page.
+  - `home.html` &mdash; The layout for your landing-page / home-page / index-page. [[More Info.](#home-layout)]
   - `page.html` &mdash; The layout for your documents that contain FrontMatter, but are not posts.
   - `post.html` &mdash; The layout for your posts.
 
@@ -67,6 +67,25 @@ This directory can include sub-directories to manage assets of similar type, and
 
 
 ## Usage
+
+### Home Layout
+
+`home.html` is a flexible HTML layout for the site's landing-page / home-page / index-page. <br/>
+
+#### Main Heading and Content-injection
+
+From Minima v2.2 onwards, the *home* layout will inject all content from your `index.md` / `index.html` **before** the **`Posts`** heading. This will allow you to include non-posts related content to be published on the landing page under a dedicated heading. *We recommended that you title this section with a Heading2 (`##`)*.
+
+Usually the `site.title` itself would suffice as the implicit 'main-title' for a landing-page. But, if your landing-page would like a heading to be explicitly displayed, then simply define a `title` variable in the document's front matter and it will be rendered with an `<h1>` tag.
+
+#### Post Listing
+
+This section is optional from Minima v2.2 onwards.<br/>
+It will be automatically included only when your site contains one or more valid posts or drafts (if the site is configured to `show_drafts`).
+
+The title for this section is `Posts` by default and rendered with an `<h2>` tag. You can customize this heading by defining a `list_title` variable in the document's front matter.
+
+--
 
 ### Customization
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -3,24 +3,28 @@ layout: default
 ---
 
 <div class="home">
+  {% if page.title %}
+    <h1 class="page-heading">{{ page.title }}</h1>
+  {% endif %}
 
   {{ content }}
 
-  <h1 class="page-heading">Posts</h1>
-  
-  <ul class="post-list">
-    {% for post in site.posts %}
-      <li>
-        {% assign date_format = site.minima.date_format | default: "%b %-d, %Y" %}
-        <span class="post-meta">{{ post.date | date: date_format }}</span>
+  {% if site.posts.size > 0 %}
+  <h2 class="post-list-heading">{{ page.list_title | default: "Posts" }}</h2>
+    <ul class="post-list">
+      {% for post in site.posts %}
+        <li>
+          {% assign date_format = site.minima.date_format | default: "%b %-d, %Y" %}
+          <span class="post-meta">{{ post.date | date: date_format }}</span>
 
-        <h2>
-          <a class="post-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
-        </h2>
-      </li>
-    {% endfor %}
-  </ul>
+          <h3>
+            <a class="post-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
+          </h3>
+        </li>
+      {% endfor %}
+    </ul>
 
-  <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | relative_url }}">via RSS</a></p>
+    <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | relative_url }}">via RSS</a></p>
+  {% endif %}
 
 </div>

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -180,7 +180,11 @@
 }
 
 .page-heading {
-  @include relative-font-size(1.25);
+  @include relative-font-size(2);
+}
+
+.post-list-heading {
+  @include relative-font-size(1.75);
 }
 
 .post-list {


### PR DESCRIPTION
Fixes #136 

Allow greater flexibility with the `home` layout

### Notable changes
  - Main heading can now be set via `index.md` with front matter key `title`
  - This heading will now have the default size of `2em` from earlier `1.25em`
  - `Posts` is now an `h2` heading and can be altered with fm-key `list_title`
  - The entire Posts Listing and feed-link is now rendered only if the site has 1 or more `posts`

/cc @benbalter 