### PR TITLE
Add Microformats markup

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-<footer class="site-footer">
+<footer class="site-footer h-card">
 
   <div class="wrapper">
 
@@ -7,7 +7,7 @@
     <div class="footer-col-wrapper">
       <div class="footer-col footer-col-1">
         <ul class="contact-list">
-          <li>
+          <li class="p-name">
             {% if site.author %}
               {{ site.author | escape }}
             {% else %}
@@ -15,7 +15,7 @@
             {% endif %}
             </li>
             {% if site.email %}
-            <li><a href="mailto:{{ site.email }}">{{ site.email }}</a></li>
+            <li><a class="u-email" href="mailto:{{ site.email }}">{{ site.email }}</a></li>
             {% endif %}
         </ul>
       </div>
@@ -43,4 +43,5 @@
 
   </div>
 
+  <a class="u-url" href="{{ "/" | relative_url }}" hidden></a>
 </footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,5 @@
 <footer class="site-footer h-card">
+  <data class="u-url" href="{{ "/" | relative_url }}"></data>
 
   <div class="wrapper">
 
@@ -43,5 +44,4 @@
 
   </div>
 
-  <a class="u-url" href="{{ "/" | relative_url }}" hidden></a>
 </footer>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,8 +3,8 @@
   <div class="wrapper">
     {% assign default_paths = site.pages | map: "path" %}
     {% assign page_paths = site.header_pages | default: default_paths %}
-    <a class="site-title" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
-  
+    <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
+
     {% if page_paths %}
       <nav class="site-nav">
         <input type="checkbox" id="nav-trigger" class="nav-trigger" />

--- a/_includes/icon-github.html
+++ b/_includes/icon-github.html
@@ -1,1 +1,1 @@
-<a rel="me" href="https://github.com/{{ include.username }}"><span class="icon icon--github">{% include icon-github.svg %}</span><span class="username">{{ include.username }}</span></a>
+<a class="u-url" rel="me" href="https://github.com/{{ include.username }}"><span class="icon icon--github">{% include icon-github.svg %}</span><span class="username">{{ include.username }}</span></a>

--- a/_includes/icon-github.html
+++ b/_includes/icon-github.html
@@ -1,1 +1,1 @@
-<a href="https://github.com/{{ include.username }}"><span class="icon icon--github">{% include icon-github.svg %}</span><span class="username">{{ include.username }}</span></a>
+<a rel="me" href="https://github.com/{{ include.username }}"><span class="icon icon--github">{% include icon-github.svg %}</span><span class="username">{{ include.username }}</span></a>

--- a/_includes/icon-twitter.html
+++ b/_includes/icon-twitter.html
@@ -1,1 +1,1 @@
-<a href="https://twitter.com/{{ include.username }}"><span class="icon icon--twitter">{% include icon-twitter.svg %}</span><span class="username">{{ include.username }}</span></a>
+<a rel="me" href="https://twitter.com/{{ include.username }}"><span class="icon icon--twitter">{% include icon-twitter.svg %}</span><span class="username">{{ include.username }}</span></a>

--- a/_includes/icon-twitter.html
+++ b/_includes/icon-twitter.html
@@ -1,1 +1,1 @@
-<a rel="me" href="https://twitter.com/{{ include.username }}"><span class="icon icon--twitter">{% include icon-twitter.svg %}</span><span class="username">{{ include.username }}</span></a>
+<a class="u-url" rel="me" href="https://twitter.com/{{ include.username }}"><span class="icon icon--twitter">{% include icon-twitter.svg %}</span><span class="username">{{ include.username }}</span></a>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,25 +1,27 @@
 ---
 layout: default
 ---
-<article class="post" itemscope itemtype="http://schema.org/BlogPosting">
+<article class="post h-entry" itemscope itemtype="http://schema.org/BlogPosting">
 
   <header class="post-header">
-    <h1 class="post-title" itemprop="name headline">{{ page.title | escape }}</h1>
+    <h1 class="post-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
     <p class="post-meta">
-      <time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
+      <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
         {% assign date_format = site.minima.date_format | default: "%b %-d, %Y" %}
         {{ page.date | date: date_format }}
       </time>
       {% if page.author %}
-        • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>
+        • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span class="p-author h-card" itemprop="name">{{ page.author }}</span></span>
       {% endif %}</p>
   </header>
 
-  <div class="post-content" itemprop="articleBody">
+  <div class="post-content e-content" itemprop="articleBody">
     {{ content }}
   </div>
 
   {% if site.disqus.shortname %}
     {% include disqus_comments.html %}
   {% endif %}
+
+  <a class="u-url" href="{{ page.url | relative_url }}" hidden></a>
 </article>


### PR DESCRIPTION
This PR adds [Microformats](http://microformats.org/wiki/microformats2) markup to Minima's templates to make post content machine-readable and discoverable.

Microformats makes HTML content as easy to consume as JSON APIs without needing a separate feed. [Parser libraries](https://microformats.io) are available for Ruby, Python, PHP, Node and Go and more.

W3C recommended protocols, including [Webmention](https://www.w3.org/TR/webmention/) and [Micropub](https://www.w3.org/TR/micropub/) depend on Microformats and so it would be a great help for the default Jekyll theme's templates to support them.

- [Example Jekyll post with Microformats markup](https://barryf.github.io/jekyll/update/2017/09/21/welcome-to-jekyll.html)
- [JSON output from Microformats parser](http://pin13.net/mf2/?url=https%3A%2F%2Fbarryf.github.io%2Fjekyll%2Fupdate%2F2017%2F09%2F21%2Fwelcome-to-jekyll.html)

I've tried to make the changes as lightweight as possible, but I'm open to any suggestions or improvements.
