### PR TITLE
Support for non-default Jekyll Feed path

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {% seo %}
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
-  <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | relative_url }}">
+  <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ site.feed.path | default: "/feed.xml" | relative_url }}">
   {% if jekyll.environment == 'production' and site.google_analytics %}
     {% include google-analytics.html %}
   {% endif %}


### PR DESCRIPTION
Jekyll Feed has an option for [non-default path](https://github.com/jekyll/jekyll-feed#already-have-a-feed-path).
If specified, it should be used for the feed link in head.html instead of the default path.