### PR TITLE
Allow for header logo instead of site title

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,8 +3,13 @@
   <div class="wrapper">
     {% assign default_paths = site.pages | map: "path" %}
     {% assign page_paths = site.header_pages | default: default_paths %}
-    <a class="site-title" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
-  
+    {% if site.header_logo %}
+      <a class="site-title" href="{{ "/" | relative_url }}">
+        <img alt="{{site.title}}" src="{{site.header_logo | relative_url}}">
+      </a>
+    {% else %}
+      <a class="site-title" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
+    {% endif %}
     {% if page_paths %}
       <nav class="site-nav">
         <input type="checkbox" id="nav-trigger" class="nav-trigger" />


### PR DESCRIPTION
Hi there, thanks for Minima! This PR allows for something like:
```yaml
title: My Awesome Site
header_logo: images/site_logo.png
email: myemail@mydomain.com
```
...so that you can use a header logo instead of site title text.