### PR TITLE
Cache includes that do not depend on page data

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
 
   <body>
 
-    {% include header.html %}
+    {% include_cached header.html %}
 
     <main class="page-content" aria-label="Content">
       <div class="wrapper">
@@ -13,7 +13,7 @@
       </div>
     </main>
 
-    {% include footer.html %}
+    {% include_cached footer.html %}
 
   </body>
 

--- a/minima.gemspec
+++ b/minima.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_runtime_dependency "jekyll", "~> 3.5"
+  spec.add_runtime_dependency "jekyll-include-cache", "~> 0.1"
   spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.1"
   spec.add_development_dependency "bundler", "~> 1.12"
 end


### PR DESCRIPTION
Includes such has `header.html` and `footer.html` are prime candidates for being cached:
  - they are **page-agnostic** &mdash; they're the same for every page, for every url (where they're rendered..)
  - they employ expensive Liquid `for` loop computation
`{% for item in list %} do something {% endfor %}`

This cache-ing can be made possible by using the [`jekyll-include-cache`](https://github.com/benbalter/jekyll-include-cache) launched in December 2017
