### PR TITLE
Update description comment in _config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: Your awesome title
 author: GitHub User
 email: your-email@domain.com
-description: > # this means to ignore newlines until "baseurl:"
+description: > # this means to ignore newlines until "twitter_username:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.


### PR DESCRIPTION
The `baseurl:` does't exists in the *_config* file.