### PR TITLE
Update config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,8 +40,12 @@ minima:
 # - about.html
 
 # Build settings
-markdown: kramdown
 theme: minima
+
+plugins:
+ - jekyll-feed
+ - jekyll-seo-tag
+
 exclude:
   - Gemfile
   - Gemfile.lock

--- a/_config.yml
+++ b/_config.yml
@@ -45,7 +45,3 @@ theme: minima
 plugins:
  - jekyll-feed
  - jekyll-seo-tag
-
-exclude:
-  - Gemfile
-  - Gemfile.lock


### PR DESCRIPTION
Link to feed is broken on https://jekyll.github.io/minima/ I guess it's because we have to tell in the config that the theme uses the `jekyll-feed` plugin.

Also listed `jekyll-seo-tag` to be consistent

- [x] remove useless directives as we already have defaults defined for markdown engine and excluded files.

fix #227 