### PR TITLE
Remove Internet Explorer 8/9 tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,5 @@
 <head>
   <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {%- seo -%}
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">


### PR DESCRIPTION
Setting `X-UA-Compatible` to `IE=edge` only seems relevant for preventing quirks mode in IE 9 and earlier; see <https://stackoverflow.com/questions/6771258/what-does-meta-http-equiv-x-ua-compatible-content-ie-edge-do> for an explanation.