### PR TITLE
Added word-break for article body

### DIFF
--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -252,3 +252,7 @@ table {
     border: 1px solid $grey-color-light;
   }
 }
+
+article {
+  word-break: break-word; 
+}


### PR DESCRIPTION
Sometimes we will put a long URL into article, it will break the page width. Add word-break property will be better.