### PR TITLE
Update Tables to Show Scrollbars on Mobile

### DIFF
--- a/_posts/2016-05-20-this-post-demonstrates-post-content-styles.md
+++ b/_posts/2016-05-20-this-post-demonstrates-post-content-styles.md
@@ -89,17 +89,81 @@ Proin eget nibh a massa vestibulum pretium. Suspendisse eu nisl a ante aliquet b
 
 ### Tables
 
-Title 1               | Title 2               | Title 3               | Title 4
---------------------- | --------------------- | --------------------- | ---------------------
-lorem                 | lorem ipsum           | lorem ipsum dolor     | lorem ipsum dolor sit
-lorem ipsum dolor sit | lorem ipsum dolor sit | lorem ipsum dolor sit | lorem ipsum dolor sit
-lorem ipsum dolor sit | lorem ipsum dolor sit | lorem ipsum dolor sit | lorem ipsum dolor sit
-lorem ipsum dolor sit | lorem ipsum dolor sit | lorem ipsum dolor sit | lorem ipsum dolor sit
+<div class="mobile-side-scroller">
 
+<table>
+  <thead>
+    <tr>
+      <th>Title 1</th>
+      <th>Title 2</th>
+      <th>Title 3</th>
+      <th>Title 4</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>lorem</td>
+    <td>lorem ipsum</td>
+    <td>lorem ipsum dolor</td>
+    <td>lorem ipsum dolor sit</td>
+  </tr>
+  <tr>
+    <td>lorem ipsum dolor sit</td>
+    <td>lorem ipsum dolor sit</td>
+    <td>lorem ipsum dolor sit</td>
+    <td>lorem ipsum dolor sit</td>
+  </tr>
+  <tr>
+    <td>lorem ipsum dolor sit</td>
+    <td>lorem ipsum dolor sit</td>
+    <td>lorem ipsum dolor sit</td>
+    <td>lorem ipsum dolor sit</td>
+  </tr>
+  <tr>
+    <td>lorem ipsum dolor sit</td>
+    <td>lorem ipsum dolor sit</td>
+    <td>lorem ipsum dolor sit</td>
+    <td>lorem ipsum dolor sit</td>
+  </tr>
+  </tbody>
+</table>
+</div>
 
-Title 1 | Title 2 | Title 3 | Title 4
---- | --- | --- | ---
-lorem | lorem ipsum | lorem ipsum dolor | lorem ipsum dolor sit
-lorem ipsum dolor sit amet | lorem ipsum dolor sit amet consectetur | lorem ipsum dolor sit amet | lorem ipsum dolor sit
-lorem ipsum dolor | lorem ipsum | lorem | lorem ipsum
-lorem ipsum dolor | lorem ipsum dolor sit | lorem ipsum dolor sit amet | lorem ipsum dolor sit amet consectetur
+<div class="mobile-side-scroller">
+<table>
+<thead>
+  <tr>
+    <th>Title 1</th>
+    <th>Title 2</th>
+    <th>Title 3</th>
+    <th>Title 4</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>lorem</td>
+    <td>lorem ipsum</td>
+    <td>lorem ipsum dolor</td>
+    <td>lorem ipsum dolor sit</td>
+  </tr>
+  <tr>
+    <td>lorem ipsum dolor sit amet</td>
+    <td>lorem ipsum dolor sit amet consectetur</td>
+    <td>lorem ipsum dolor sit amet</td>
+    <td>lorem ipsum dolor sit</td>
+  </tr>
+  <tr>
+    <td>lorem ipsum dolor</td>
+    <td>lorem ipsum</td>
+    <td>lorem</td>
+    <td>lorem ipsum</td>
+  </tr>
+  <tr>
+    <td>lorem ipsum dolor</td>
+    <td>lorem ipsum dolor sit</td>
+    <td>lorem ipsum dolor sit amet</td>
+    <td>lorem ipsum dolor sit amet consectetur</td>
+  </tr>
+</tbody>
+</table>
+</div>

--- a/_sass/minima.scss
+++ b/_sass/minima.scss
@@ -39,6 +39,17 @@ $on-laptop:        800px !default;
   }
 }
 
+@media (max-width: 768px) {
+  .mobile-side-scroller {
+    overflow-x: scroll;
+    /*margin: 0 -40px;*/
+    margin: 0 auto;
+    padding: 0 10px;
+    max-width: 90%;
+  }
+}
+
+
 @mixin relative-font-size($ratio) {
   font-size: $base-font-size * $ratio;
 }


### PR DESCRIPTION
I updated Minima to cause scrollbars to appear on tables on mobile devices/small screens if the screen size is too small to display the entire table. This is to address the problem of tables not overflow and distorting the mobile experience which was mentioned in [https://github.com/jekyll/minima/issues/243](https://github.com/jekyll/minima/issues/243).

 I set it up to follow the same conventions as [https://github.com/jekyll/jekyll](https://github.com/jekyll/jekyll).  However, in order to implement this functionality, users have to use HTML instead of Markdown for their tables since the CSS styling cannot be added without a specific div class being defined around every table. Is this trade-off okay?