### PR TITLE
Footer overlapping issue (Support Microsoft Explorer 11)

### DIFF
--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -177,7 +177,7 @@
  */
 .page-content {
   padding: $spacing-unit 0;
-  flex: 1;
+  flex: 1 0 auto;
 }
 
 .page-heading {


### PR DESCRIPTION
To solve the issue [#247](https://github.com/jekyll/minima/issues/247), flex properties of page-content in `_layout.scss` are changed.


**before**
![image](https://user-images.githubusercontent.com/38124811/40986420-1ae3a1c8-6921-11e8-9f30-059e3864c6dd.png)

**after**
![image](https://user-images.githubusercontent.com/38124811/40986456-3373b66a-6921-11e8-9bb3-aaa6571fb84c.png)
