### PR TITLE
Fix example header_pages in config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,7 +37,7 @@ minima:
 # If you want to link only specific pages in your header, uncomment
 # this and add the path to the pages in order as they should show up
 #header_pages:
-# - about.html
+# - about.md
 
 # Build settings
 theme: minima


### PR DESCRIPTION
Change path to `about.md`, since `about.html` is confusing.

Fixes #253.