### PR TITLE
WIP: Load default favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Comments are enabled by default and will only appear in production, i.e., `JEKYL
 
 If you don't want to display comments for a particular post you can disable them by adding `comments: false` to that post's YAML Front Matter.
 
+Don't forget to set the "url" field in the config file (include http/https).
+
 --
 
 ### Social networks

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="{{ page.lang | default: site.lang | default: "en" }}">
 
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico?">
+
   {%- include head.html -%}
 
   <body>


### PR DESCRIPTION
The current branch doesn't seem to load the favicon for me (Mac OS X,
Chrome).

Using this solution fixed it: https://stackoverflow.com/questions/30551501/unable-to-set-favicon-using-jekyll-and-github-pages/30552322

https://github.com/jekyll/minima/pull/270