### PR TITLE
Load favicon

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="{{ page.lang | default: site.lang | default: "en" }}">
 
+<link rel="shortcut icon" type="image/x-icon" href="{{ "/favicon.ico?" | relative_url }}">
+
   {%- include head.html -%}
 
   <body>


### PR DESCRIPTION
The current branch doesn't seem to load the favicon for me (Mac OS X,
Chrome).

Using this solution fixed it: https://stackoverflow.com/questions/30551501/unable-to-set-favicon-using-jekyll-and-github-pages/30552322

#270