### PR TITLE
Fix site title line height

### DIFF
--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -5,6 +5,7 @@
   border-top: 5px solid $grey-color-dark;
   border-bottom: 1px solid $grey-color-light;
   min-height: $spacing-unit * 1.865;
+  line-height: $base-line-height * $base-font-size * 2.25;
 
   // Positioning context for the mobile navigation icon
   position: relative;
@@ -13,7 +14,6 @@
 .site-title {
   @include relative-font-size(1.625);
   font-weight: 300;
-  line-height: $base-line-height;
   letter-spacing: -1px;
   margin-bottom: 0;
   float: left;
@@ -36,7 +36,6 @@
   border: 1px solid $grey-color-light;
   border-radius: 5px;
   text-align: right;
-  line-height: $base-line-height * $base-font-size * 2.25;
 
   .nav-trigger {
       display: none;


### PR DESCRIPTION
The original code did not apply the proper `line-height` to the site title, offsetting it vertically from the center.

Before:
<img width="769" alt="screenshot 2018-11-22 at 13 17 48" src="https://user-images.githubusercontent.com/225410/48902640-72c7d900-ee59-11e8-8e1d-d102545b29d3.png">

After:
<img width="760" alt="screenshot 2018-11-22 at 13 18 16" src="https://user-images.githubusercontent.com/225410/48902643-78bdba00-ee59-11e8-9a3c-2b183635b034.png">

