### PR TITLE
Fix missing </header> bug.

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,3 +1,4 @@
+
 <header class="site-header">
 
   <div class="wrapper">


### PR DESCRIPTION
Add a new line at start of `_includes/header.html` so that `</header>` won't missing after run `jekyll build`.