### PR TITLE
 Add `overflow-wrap: break-word` to body tag

### DIFF
--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -27,6 +27,7 @@ body {
   display: flex;
   min-height: 100vh;
   flex-direction: column;
+  overflow-wrap: break-word;
 }
 
 


### PR DESCRIPTION
 https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap

![combined](https://user-images.githubusercontent.com/6443532/49679336-433ce180-fa93-11e8-96d7-418b40bcf331.png)

closes #306  