### PR TITLE
Add pre-Safari 9.0 functionality in viewport tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1 shrink-to-fit=no">
   {%- seo -%}
   <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
   {%- feed_meta -%}


### PR DESCRIPTION
After iOS 9 release, Safari browser zooms out everything automatically. However, suggested change into Minima theme viewport meta tag will fix the initial zoom problem.