### PR TITLE
Fix CSS customization docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,26 +94,26 @@ The title for this section is `Posts` by default and rendered with an `<h2>` tag
 To override the default structure and style of minima, simply create the concerned directory at the root of your site, copy the file you wish to customize to that directory, and then edit the file.
 e.g., to override the [`_includes/head.html `](_includes/head.html) file to specify a custom style path, create an `_includes` directory, copy `_includes/head.html` from minima gem folder to `<yoursite>/_includes` and start editing that file.
 
-The site's default CSS has now moved to a new place within the gem itself, [`assets/css/style.scss`](assets/css/style.scss). To **override the default CSS**, the file has to exist at your site source. Do either of the following:
+The site's default CSS has now moved to a new place within the gem itself, [`assets/main.scss`](assets/main.scss). To **override the default CSS**, the file has to exist at your site source. Do either of the following:
 - Create a new instance at site source.
-  - Create a new file at `<your-site>/assets/css/style.scss`
+  - Create a new file at `<your-site>/assets/main.scss`
   - Add the frontmatter dashes, and
   - Add `@import "minima";`
   - Add your custom CSS.
 - Download the file from this repo
-  - Create  a new file at `<your-site>/assets/css/style.scss`
-  - Copy the contents at [assets/css/style.scss](assets/css/style.scss) onto the `css/style.scss` you just created, and edit away!
+  - Create  a new file at `<your-site>/assets/main.scss`
+  - Copy the contents at [assets/main.scss](assets/main.scss) onto the `main.scss` you just created, and edit away!
 - Copy directly from minima gem
   - Go to your local minima gem installation directory ( run `bundle show minima` to get the path to it ).
   - Copy the `assets/` folder from there into the root of `<your-site>`
-  - Change whatever values you want, inside `<your-site>/assets/css/style.scss`
+  - Change whatever values you want, inside `<your-site>/assets/main.scss`
 
 
 When you override only a minima-sass-partial, it is not automatically imported because we're still importing the `minima.scss` within the theme-gem and that subsequently imports the partials with respect to itself, i.e. partials within the gem. Hence you should either include a *copy of `minima.scss` from the gem* inside the `_sass` directory at source or the overriding `/assets/css/style.scss` file should explicitly import the edited partial. :
   e.g. To have an **edited** `_syntax-highlighting.scss` be rendered, you should either have
 
 ```sass
-/* <your-site>/assets/css/style.scss */
+/* <your-site>/assets/main.scss */
 
 @import "minima";
 @import "minima/syntax-highlighting";
@@ -131,7 +131,7 @@ your `<your-site>/_sass/` should look like:
 To have your CSS overrides in sync with upstream changes released in future versions, collect all your overrides into a single partial sass-file and then import that partial after importing minima, like so:
 
 ```sass
-/* <your-site>/assets/css/style.scss */
+/* <your-site>/assets/main.scss */
 
 @import "minima";
 @import "my_overrides";


### PR DESCRIPTION
I was trying to customize my Jekyll blog's CSS and found that the path for the main scss file (for minima 2.5.0) is assets/main.scss, and that's what you have to recreate in your own Jekyll repo to get customizations to work. It is not /assets/css/style.scss (creating this does nothing).

Here's what I mean: https://github.com/ksm/blog.mazur.me/commit/b99369ea09ca8c095fcb1eb03703d683cb9575f5. This commit got CSS overrides to work on my blog.