### PR TITLE
Update multiline config comment.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: Your awesome title
 author: GitHub User
 email: your-email@domain.com
-description: > # this means to ignore newlines until "twitter_username:"
+description: > # this means to ignore newlines until "show_exerpts:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.


### PR DESCRIPTION
I don't know if the existing comment reflected something I don't understand. Since the `twitter_username` field is no longer present at all, though, it felt like something that simply needed to be updated after the config file evolved.
