### PR TITLE
Fix footer stacking issue for smaller view sizes

### DIFF
--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -292,7 +292,9 @@
 /**
  * Grid helpers
  */
-.one-half {
-  width: -webkit-calc(50% - (#{$spacing-unit} / 2));
-  width:         calc(50% - (#{$spacing-unit} / 2));
+@media screen and (min-width: $on-large) {
+  .one-half {
+    width: -webkit-calc(50% - (#{$spacing-unit} / 2));
+    width:         calc(50% - (#{$spacing-unit} / 2));
+  }
 }


### PR DESCRIPTION
Hi 👋, this is my first PR to the minima project.

## Bug

For smaller view sizes, the footer leaves an empty column of space.

Like this:

![Broken footer](https://user-images.githubusercontent.com/34559231/59544681-ef142d80-8f0b-11e9-8b7e-eb8bc29ea869.png)

## Fix

Remove the columns for these smaller view sizes by wrapping `.one-half` in a media query using `$on-large`.

So it now looks like this:

![Fixed footer](https://user-images.githubusercontent.com/34559231/59544697-300c4200-8f0c-11e9-8cc4-98da235c17cd.png)

The footer on larger view sizes is unchanged.