### PR TITLE
Allow use and testing with Jekyll 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: ruby
 cache: bundler
-sudo: false
-rvm: 2.4
+rvm:
+  - 2.6
+  - 2.4
 
+before_install: gem update --system --no-document
 install: script/bootstrap
 script: script/cibuild
+
+env:
+  matrix:
+    - JEKYLL_VERSION="~> 3.5"
+    - JEKYLL_VERSION=">= 4.0.0.pre.alpha1"

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@
 
 source "https://rubygems.org"
 gemspec
+
+gem "jekyll", ENV["JEKYLL_VERSION"] if ENV["JEKYLL_VERSION"]

--- a/minima.gemspec
+++ b/minima.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |spec|
     f.match(%r!^(assets|_(includes|layouts|sass)/|(LICENSE|README)((\.(txt|md|markdown)|$)))!i)
   end
 
-  spec.add_runtime_dependency "jekyll", "~> 3.5"
+  spec.add_runtime_dependency "jekyll", ">= 3.5", "< 5.0"
   spec.add_runtime_dependency "jekyll-feed", "~> 0.9"
   spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.1"
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler", ">= 1.15"
 end


### PR DESCRIPTION
This adds Jekyll 4.0 support to **`2.5-stable`** branch by backporting #351 (and some additional minor changes to `.travis.yml`).

@DirtyF, @mattr-  IMO, a `minima-2.5.1` should be deployed a.s.a.p *before shipping Jekyll 4.0* so that
using `jekyll new` with Jekyll 4.0 allows using Minima 2.5 by default.