### PR TITLE
Set the border radius of highlight

### DIFF
--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -171,6 +171,7 @@ pre {
 }
 
 .highlight {
+  border-radius: 3px;
   background: $code-background-color;
   @extend %vertical-rhythm;
 


### PR DESCRIPTION
I discovered the corners of code blocks look not correct currently.

<img width="428" alt="屏幕快照 2020-01-03 上午11 38 08" src="https://user-images.githubusercontent.com/59011975/71706195-4f25df00-2e1e-11ea-80fb-9da511d4e173.png">

That's because the `border-radius` of `.highlight` didn't set, so I fix it now.