### PR TITLE
Unguarded feed links

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {%- seo -%}
   <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
-  {%- feed_meta -%}
+  {%- if site.minima.social_links.rss -%}
+    {%- feed_meta -%}
+  {%- endif -%}
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
     {%- include google-analytics.html -%}
   {%- endif -%}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -28,11 +28,13 @@ layout: default
       {%- endfor -%}
     </ul>
 
-    <p class="feed-subscribe">
-      <a href="{{ 'feed.xml' | relative_url }}">
-        <svg class="svg-icon orange"><use xlink:href="{{ 'assets/minima-social-icons.svg#rss' | relative_url }}"></use></svg><span>Subscribe</span>
-      </a>
-    </p>
+    {%- if site.minima.social_links.rss -%}
+      <p class="feed-subscribe">
+        <a href="{{ 'feed.xml' | relative_url }}">
+          <svg class="svg-icon orange"><use xlink:href="{{ 'assets/minima-social-icons.svg#rss' | relative_url }}"></use></svg><span>Subscribe</span>
+        </a>
+      </p>
+    {%- endif -%}
   {%- endif -%}
 
 </div>


### PR DESCRIPTION
There's [a guard on the RSS link in the footer](https://github.com/jekyll/minima/blob/master/_includes/social.html#L18), yet if `site.minima.social_links.rss` is falsey, feed details still show up in the `<head>` and the home layout.

This pull request just wraps those snippets in conditions.