### PR TITLE
Add a placeholder of favicons

### DIFF
--- a/_includes/favicons.html
+++ b/_includes/favicons.html
@@ -1,1 +1,1 @@
-<!-- Placeholder to allow defining custom favicons -->
+{% comment %}Placeholder to allow defining custom favicons{% endcomment %}

--- a/_includes/favicons.html
+++ b/_includes/favicons.html
@@ -1,0 +1,1 @@
+<!-- Placeholder to allow defining custom favicons -->

--- a/_includes/favicons.html
+++ b/_includes/favicons.html
@@ -1,1 +1,6 @@
-{% comment %}Placeholder to allow defining custom favicons{% endcomment %}
+{% comment %}
+  Placeholder to allow defining custom favicons
+
+  1. Head over to https://realfavicongenerator.net/ to add your own favicons.
+  2. Customize default _includes/favicons.html in your source directory and insert the given code snippet.
+{% endcomment %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  {%- include favicons.html -%}
   {%- seo -%}
   <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
   {%- feed_meta -%}


### PR DESCRIPTION
Add a placeholder of favicons, so that users do not need to override the whole `head.html` to configure favicons, instead, just override `favicons.html`.
