### PR TITLE
Use "em" unit in relative-font-size mixin

### DIFF
--- a/_sass/minima/initialize.scss
+++ b/_sass/minima/initialize.scss
@@ -37,7 +37,7 @@ $on-large:         $on-laptop !default;
 }
 
 @mixin relative-font-size($ratio) {
-  font-size: $base-font-size * $ratio;
+  font-size: #{$ratio}em;
 }
 
 // Import pre-styling-overrides hook and style-partials.


### PR DESCRIPTION
This fixes the issue where nested elements were rendered incorrectly (e.g. `<code>` nested under headings `<h1>`..`<h6>`) because of using `px` units.

Resolves #92 
Closes #304 
Closes #372
Closes #394 