### PR TITLE
Use "rem" unit in relative-font-size mixin

### DIFF
--- a/History.markdown
+++ b/History.markdown
@@ -21,7 +21,6 @@
   * Add missing rel=me attributes to social links (#386)
   * Set the border radius of highlight (#426)
   * Removed unnecessary whitespace-controls (#390)
-  * Use &#34;em&#34; unit in relative-font-size mixin (#435)
   * fix: overflow auto for tables (#296)
   *  Add `overflow-wrap: break-word` to body tag (#321)
 

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -150,7 +150,7 @@ blockquote {
  */
 pre,
 code {
-  @include relative-font-size(0.9375);
+  font-size: 0.9375em;
   border: 1px solid $brand-color-light;
   border-radius: 3px;
   background-color: $code-background-color;

--- a/_sass/minima/initialize.scss
+++ b/_sass/minima/initialize.scss
@@ -37,7 +37,7 @@ $on-large:         $on-laptop !default;
 }
 
 @mixin relative-font-size($ratio) {
-  font-size: #{$ratio}em;
+  font-size: #{$ratio}rem;
 }
 
 // Import pre-styling-overrides hook and style-partials.


### PR DESCRIPTION
This fixes a miscalculation on my part in #435 

`$base-font-size * $ratio` actually translates to using `rem` units.
Using `em` units render sizes relative to the immediate parent element (which is *not* always desirable).