### PR TITLE
Add font-size styles for elements h5 and h6

### DIFF
--- a/_posts/2016-05-20-this-post-demonstrates-post-content-styles.md
+++ b/_posts/2016-05-20-this-post-demonstrates-post-content-styles.md
@@ -59,6 +59,14 @@ In arcu magna, aliquet vel pretium et, molestie et arcu. Mauris lobortis nulla e
 
 In arcu magna, aliquet vel pretium et, molestie et arcu. Mauris lobortis nulla et felis ullamcorper bibendum. Phasellus et hendrerit mauris.
 
+##### Could be a smaller sub-heading, `pacman` (h5)
+
+In arcu magna, aliquet vel pretium et, molestie et arcu. Mauris lobortis nulla et felis ullamcorper bibendum. Phasellus et hendrerit mauris.
+
+###### Small yet significant sub-heading  (h6)
+
+In arcu magna, aliquet vel pretium et, molestie et arcu. Mauris lobortis nulla et felis ullamcorper bibendum. Phasellus et hendrerit mauris.
+
 ### Oh hai, an unordered list!!
 
 In arcu magna, aliquet vel pretium et, molestie et arcu. Mauris lobortis nulla et felis ullamcorper bibendum. Phasellus et hendrerit mauris.

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -262,11 +262,14 @@
   }
 
   h4 {
-    @include relative-font-size(1.125);
+    @include relative-font-size(1.25);
+  }
 
-    @media screen and (min-width: $on-large) {
-      @include relative-font-size(1.25);
-    }
+  h5 {
+    @include relative-font-size(1.125);
+  }
+  h6 {
+    @include relative-font-size(1.0625);
   }
 }
 


### PR DESCRIPTION
In order to prevent browsers from rendering them smaller than our `base_font_size` of 16px.

- `h5` and `h6` are a *larger* than `p` elements by couple of pixels each on all devices.
- `h5` takes on current small-screen size of `h4`
- `h4` size has been tweaked to remain at the same size on all devices.

Resolves #430 
Resolves #374 

/cc @hszhakka @alexhuangster