### PR TITLE
Align the social media list to the center

### DIFF
--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -140,13 +140,13 @@
 .footer-col-wrapper {
   @include relative-font-size(0.9375);
   color: $brand-color;
-  margin-left: -$spacing-unit / 2;
   @extend %clearfix;
 }
 
 .footer-col {
   width: -webkit-calc(100% - (#{$spacing-unit} / 2));
   width:         calc(100% - (#{$spacing-unit} / 2));
+  margin-left: -$spacing-unit / 2;
   margin-bottom: $spacing-unit / 2;
   padding-left: $spacing-unit / 2;
 }

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -140,13 +140,14 @@
 .footer-col-wrapper {
   @include relative-font-size(0.9375);
   color: $brand-color;
+  margin-left: -$spacing-unit / 2;
+  margin-right: -$spacing-unit / 2;
   @extend %clearfix;
 }
 
 .footer-col {
   width: -webkit-calc(100% - (#{$spacing-unit} / 2));
   width:         calc(100% - (#{$spacing-unit} / 2));
-  margin-left: -$spacing-unit / 2;
   margin-bottom: $spacing-unit / 2;
   padding-left: $spacing-unit / 2;
 }


### PR DESCRIPTION
Currently, the social media list in the footer is not aligned to the center:

<img width="936" alt="屏幕快照 2020-01-19 下午6 30 22" src="https://user-images.githubusercontent.com/59011975/72679414-d98e6400-3ae9-11ea-9db1-bbed59a24d48.png">

That's because the `margin-left` of `footer-col-wrapper` is specified as `-$spacing-unit / 2`. For fixing the alignment of the social media list, we should specify `footer-col` instead of the whole `footer-col-wrapper`:

<img width="837" alt="屏幕快照 2020-01-19 下午6 34 32" src="https://user-images.githubusercontent.com/59011975/72679467-6d603000-3aea-11ea-8593-396a9e1e5ee5.png">
