### PR TITLE
Fix the layout of footer columns

### DIFF
--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -268,7 +268,6 @@
 
 
 .social-media-list {
-  border: 1px solid yellow;
   display: table;
   margin: 0 auto;
   li {

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -140,14 +140,13 @@
 .footer-col-wrapper {
   @include relative-font-size(0.9375);
   color: $brand-color;
-  margin-left: -$spacing-unit / 2;
   @extend %clearfix;
 }
 
 .footer-col {
   width: calc(100% - (#{$spacing-unit} / 2));
   margin-bottom: $spacing-unit / 2;
-  padding-left: $spacing-unit / 2;
+  margin-right: $spacing-unit / 2;
 }
 
 .footer-col-1,
@@ -269,6 +268,7 @@
 
 
 .social-media-list {
+  border: 1px solid yellow;
   display: table;
   margin: 0 auto;
   li {


### PR DESCRIPTION
This PR is mainly for solving the misalignment of the social media list, that could be easily seen on mobile phones:

![IMG_3677](https://user-images.githubusercontent.com/59011975/72773627-aca19480-3c42-11ea-93ee-efc189ae44fd.PNG)

I discovered that it is caused by the `margin-left` of `.footer-col-wrapper`, so I deleted it. However, after this modification, the footer columns didn't align to the left:

<img width="642" alt="屏幕快照 2020-01-21 上午11 45 36" src="https://user-images.githubusercontent.com/59011975/72773930-baa3e500-3c43-11ea-9326-84e7f9199d8c.png">
 
So I deleted the `padding-left` of `.footer-col`, but that caused the text of description stuck to the first column:

<img width="764" alt="屏幕快照 2020-01-21 上午11 48 56" src="https://user-images.githubusercontent.com/59011975/72774120-6c431600-3c44-11ea-80a7-632650830f12.png">

So finally I added a `margin-right` to `.footer-col`. It seems to resolve the problem.

 