### PR TITLE
Re-implement site footer markup and styles

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,27 +4,24 @@
   <div class="wrapper">
 
     <div class="footer-col-wrapper">
-      <div class="footer-col one-half">
-      <h2 class="footer-heading">{{ site.title | escape }}</h2>
+      <div class="footer-col">
+        <h2 class="footer-heading">{{ site.title | escape }}</h2>
         <ul class="contact-list">
-          <li class="p-name">
-            {%- if site.author -%}
-              {{ site.author | escape }}
-            {%- endif -%}
-            </li>
-            {%- if site.email -%}
+          {% if site.author -%}
+            <li class="p-name">{{ site.author | escape }}</li>
+          {% endif -%}
+          {% if site.email -%}
             <li><a class="u-email" href="mailto:{{ site.email }}">{{ site.email }}</a></li>
-            {%- endif -%}
+          {%- endif %}
         </ul>
       </div>
-
-      <div class="footer-col one-half">
+      <div class="footer-col">
         <p>{{ site.description | escape }}</p>
       </div>
+    </div>
 
-      <div class="social-links">
-        {%- include social.html -%}
-      </div>
+    <div class="social-links">
+      {%- include social.html -%}
     </div>
 
   </div>

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -137,17 +137,14 @@
   margin-left: 0;
 }
 
-.footer-col-wrapper {
+.footer-col-wrapper,
+.social-links {
   @include relative-font-size(0.9375);
   color: $brand-color;
-  margin-left: -$spacing-unit / 2;
-  @extend %clearfix;
 }
 
 .footer-col {
-  width: calc(100% - (#{$spacing-unit} / 2));
   margin-bottom: $spacing-unit / 2;
-  padding-left: $spacing-unit / 2;
 }
 
 .footer-col-1,
@@ -174,8 +171,23 @@
 }
 
 @media screen and (min-width: $on-medium) {
+  .footer-col-wrapper {
+    display: flex
+  }
+
   .footer-col {
-    float: left;
+    width: calc(100% - (#{$spacing-unit} / 2));
+    padding: 0 ($spacing-unit / 2);
+
+    &:first-child {
+      padding-right: $spacing-unit / 2;
+      padding-left: 0;
+    }
+
+    &:last-child {
+      padding-right: 0;
+      padding-left: $spacing-unit / 2;
+    }
   }
 }
 
@@ -273,15 +285,14 @@
   margin: 0 auto;
   li {
     float: left;
-    margin: 0 5px;
-    &:first-of-type { margin-left: 0 }
+    margin: 5px 10px 5px 0;
     &:last-of-type { margin-right: 0 }
     a {
       display: block;
       padding: $spacing-unit / 4;
-      border: 1px solid $brand-color-light
+      border: 1px solid $brand-color-light;
+      &:hover { border-color: darken($brand-color-light, 10%) }
     }
-    &:hover .svg-icon { fill: currentColor; }
   }
 }
 


### PR DESCRIPTION
## Summary of fixes
- Render a list-item (for `site.author` and `site.email`) in footer only when configured.
- Make `.social-links` a sibling of the `.footer-col-wrapper` (which now includes only `footer-col` by default). So that it is always a separate block independent of the presence of `.footer-col` divs.
- Single-line `site.description` no longer breaks the layout.
- On `$medium` viewport widths and above, use flexbox to align footer columns and social-links div. Stack vertically on smaller devices.
- Adjust social link margins so that they fold nicely on all viewport sizes when numerous icons are rendered.

## Screenshot samples
### on `master`
![current render](https://user-images.githubusercontent.com/12479464/72880882-c10a8d80-3d25-11ea-8d11-1fc109088527.png)


### on this branch
![proposed render](https://user-images.githubusercontent.com/12479464/72880904-cb2c8c00-3d25-11ea-8cc3-191c0cf9f077.png)

## Context
Closes #446 