### PR TITLE
Improve readability of post titles with diacritics

### DIFF
--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -241,7 +241,7 @@
 .post-content h1 {
   @include relative-font-size(2.625);
   letter-spacing: -1px;
-  line-height: 1;
+  line-height: 1.15;
 
   @media screen and (min-width: $on-large) {
     @include relative-font-size(2.625);


### PR DESCRIPTION
Translating the title `"Some articles are just so long they deserve a really long title to see if things will break well"` into Turkish yields:

## on `master`
![current deploy](https://user-images.githubusercontent.com/12479464/72964166-240c2b00-3ddf-11ea-924a-a8eeb1903a4c.png)

Note that some characters almost touch each other across lines on `master`

---

## on this branch
![proposed deploy](https://user-images.githubusercontent.com/12479464/72964219-430abd00-3ddf-11ea-8895-133cf890e755.png)
