### PR TITLE
Set the overflow-x of pre to scroll

### DIFF
--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -162,7 +162,7 @@ code {
 
 pre {
   padding: 8px 12px;
-  overflow-x: auto;
+  overflow-x: scroll;
 
   > code {
     border: 0;


### PR DESCRIPTION
For the readability of code, we should force the `overflow-x` of `pre` to `scroll`, so that it has no chance to break the format of the source code.