### PR TITLE
Fix the line-break of code

### DIFF
--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -168,6 +168,10 @@ pre {
     border: 0;
     padding-right: 0;
     padding-left: 0;
+
+    white-space: pre;
+    word-break: normal;
+    word-wrap: normal;
   }
 }
 


### PR DESCRIPTION
On some browsers, the code in `pre` may be wrapped so that making the format looks ugly. So I add these attributes to force it can't be wrapped.