### PR TITLE
Export a variable to let users to custom the font family of code

### DIFF
--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -153,6 +153,7 @@ blockquote {
  */
 pre,
 code {
+  font-family: $code-font-family;
   font-size: 0.9375em;
   border: 1px solid $brand-color-light;
   border-radius: 3px;

--- a/_sass/minima/initialize.scss
+++ b/_sass/minima/initialize.scss
@@ -3,6 +3,7 @@
 // Define defaults for each variable.
 
 $base-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Segoe UI Symbol", "Segoe UI Emoji", "Apple Color Emoji", Roboto, Helvetica, Arial, sans-serif !default;
+$code-font-family: "Menlo", "Courier New", "Inconsolata", "Monospace";
 $base-font-size:   16px !default;
 $base-font-weight: 400 !default;
 $small-font-size:  $base-font-size * 0.875 !default;

--- a/_sass/minima/initialize.scss
+++ b/_sass/minima/initialize.scss
@@ -3,7 +3,7 @@
 // Define defaults for each variable.
 
 $base-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Segoe UI Symbol", "Segoe UI Emoji", "Apple Color Emoji", Roboto, Helvetica, Arial, sans-serif !default;
-$code-font-family: "Menlo", "Courier New", "Inconsolata", "Monospace";
+$code-font-family: "Menlo", "Inconsolata", "Consolas", "Roboto Mono", "Ubuntu Mono", "Courier New", monospace;
 $base-font-size:   16px !default;
 $base-font-weight: 400 !default;
 $small-font-size:  $base-font-size * 0.875 !default;

--- a/_sass/minima/initialize.scss
+++ b/_sass/minima/initialize.scss
@@ -3,7 +3,7 @@
 // Define defaults for each variable.
 
 $base-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Segoe UI Symbol", "Segoe UI Emoji", "Apple Color Emoji", Roboto, Helvetica, Arial, sans-serif !default;
-$code-font-family: "Menlo", "Inconsolata", "Consolas", "Roboto Mono", "Ubuntu Mono", "Courier New", monospace;
+$code-font-family: "Menlo", "Inconsolata", "Consolas", "Roboto Mono", "Ubuntu Mono", "Liberation Mono", "Courier New", monospace;
 $base-font-size:   16px !default;
 $base-font-weight: 400 !default;
 $small-font-size:  $base-font-size * 0.875 !default;


### PR DESCRIPTION
Before:

<img width="777" alt="Screenshot 2020-02-13 at 9 39 06 PM" src="https://user-images.githubusercontent.com/59011975/74440685-6c33e000-4ea9-11ea-861f-e0f966c665a6.png">

After:

<img width="772" alt="Screenshot 2020-02-13 at 9 39 49 PM" src="https://user-images.githubusercontent.com/59011975/74440691-72c25780-4ea9-11ea-9b4b-d94a662e6b2e.png">
