### PR TITLE
Remove RSS from social icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,6 @@
-# Jekyll
+.bundle
 .jekyll-cache
 .sass-cache
-_site
-
-# Bundler
-*.gem
-.bundle
 Gemfile.lock
-vendor/bundle
+_site
+*.gem

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
-.bundle
+# Jekyll
 .jekyll-cache
 .sass-cache
-Gemfile.lock
 _site
+
+# Bundler
 *.gem
+.bundle
+Gemfile.lock
+vendor/bundle

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ***Disclaimer:** The information here may vary depending on the version you're using. Please refer to the `README.md` bundled
 within the theme-gem for information specific to your version or by pointing your browser to the Git tag corresponding to your
-version. e.g. https://github.com/jekyll/minima/blob/v2.5.0/README.md*  
+version. e.g. https://github.com/jekyll/minima/blob/v2.5.0/README.md*
 *Running `bundle show minima` will provide you with the local path to your current theme version.*
 
 
@@ -235,19 +235,18 @@ From `Minima-3.0` onwards, the usernames are to be nested under `minima.social_l
 ```yaml
 minima:
   social_links:
-    twitter: jekyllrb
-    github: jekyll
-    stackoverflow: "11111"
     dribbble: jekyll
     facebook: jekyll
     flickr: jekyll
+    github: jekyll
     instagram: jekyll
-    linkedin: jekyll
-    pinterest: jekyll
-    telegram: jekyll
-    microdotblog: jekyll
     keybase: jekyll
-    rss: rss
+    linkedin: jekyll
+    microdotblog: jekyll
+    pinterest: jekyll
+    stackoverflow: "11111"
+    telegram: jekyll
+    twitter: jekyllrb
 
     mastodon:
      - username: jekyll

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ***Disclaimer:** The information here may vary depending on the version you're using. Please refer to the `README.md` bundled
 within the theme-gem for information specific to your version or by pointing your browser to the Git tag corresponding to your
-version. e.g. https://github.com/jekyll/minima/blob/v2.5.0/README.md*
+version. e.g. https://github.com/jekyll/minima/blob/v2.5.0/README.md*  
 *Running `bundle show minima` will provide you with the local path to your current theme version.*
 
 
@@ -235,18 +235,18 @@ From `Minima-3.0` onwards, the usernames are to be nested under `minima.social_l
 ```yaml
 minima:
   social_links:
+    twitter: jekyllrb
+    github: jekyll
+    stackoverflow: "11111"
     dribbble: jekyll
     facebook: jekyll
     flickr: jekyll
-    github: jekyll
     instagram: jekyll
-    keybase: jekyll
     linkedin: jekyll
-    microdotblog: jekyll
     pinterest: jekyll
-    stackoverflow: "11111"
     telegram: jekyll
-    twitter: jekyllrb
+    microdotblog: jekyll
+    keybase: jekyll
 
     mastodon:
      - username: jekyll

--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ show_excerpts: false # set to true to show excerpts on the homepage
 minima:
   date_format: "%b %-d, %Y"
 
-  # social links displayed in footer
+  # generate social links in footer
   social_links:
     twitter: jekyllrb
     github:  jekyll
@@ -48,7 +48,7 @@ minima:
     #   instance: example.com
 
 # If you want to link only specific pages in your header, uncomment
-# this and add the path to the pages in order as they should show up.
+# this and add the path to the pages in order as they should show up
 #header_pages:
 # - about.md
 

--- a/_config.yml
+++ b/_config.yml
@@ -9,11 +9,8 @@ description: > # this means to ignore newlines until "show_excerpts:"
 
 show_excerpts: false # set to true to show excerpts on the homepage
 
-# Build settings
-theme: minima
-
-# date format
-# Reference https://shopify.github.io/liquid/filters/date/
+# Minima date format
+# refer to https://shopify.github.io/liquid/filters/date/ if you want to customize this
 minima:
   date_format: "%b %-d, %Y"
 
@@ -25,16 +22,16 @@ minima:
     # dribbble: jekyll
     # facebook: jekyll
     # flickr:   jekyll
-    # googleplus: +jekyll
     # instagram: jekyll
-    # keybase: jekyll
     # linkedin: jekyll
-    # microdotblog: jekyll
     # pinterest: jekyll
-    # telegram: jekyll
-    # youtube_channel_name: CloudCannon
-    # youtube_channel: UC8CXR0-3I70i1tfPg1PAE1g
     # youtube: jekyll
+    # youtube_channel: UC8CXR0-3I70i1tfPg1PAE1g
+    # youtube_channel_name: CloudCannon
+    # telegram: jekyll
+    # googleplus: +jekyll
+    # microdotblog: jekyll
+    # keybase: jekyll
 
     # Mastodon instances
     # mastodon:
@@ -50,10 +47,13 @@ minima:
     # - username: jekyll2
     #   instance: example.com
 
-# If you want to link only specific pages in the header, uncomment
+# If you want to link only specific pages in your header, uncomment
 # this and add the path to the pages in order as they should show up.
 #header_pages:
 # - about.md
+
+# Build settings
+theme: minima
 
 plugins:
  - jekyll-feed

--- a/_config.yml
+++ b/_config.yml
@@ -9,30 +9,32 @@ description: > # this means to ignore newlines until "show_excerpts:"
 
 show_excerpts: false # set to true to show excerpts on the homepage
 
-# Minima date format
-# refer to https://shopify.github.io/liquid/filters/date/ if you want to customize this
+# Build settings
+theme: minima
+
+# date format
+# Reference https://shopify.github.io/liquid/filters/date/
 minima:
   date_format: "%b %-d, %Y"
 
-  # generate social links in footer
+  # social links displayed in footer
   social_links:
     twitter: jekyllrb
     github:  jekyll
-    rss: rss
     # devto: jekyll
     # dribbble: jekyll
     # facebook: jekyll
     # flickr:   jekyll
-    # instagram: jekyll
-    # linkedin: jekyll
-    # pinterest: jekyll
-    # youtube: jekyll
-    # youtube_channel: UC8CXR0-3I70i1tfPg1PAE1g
-    # youtube_channel_name: CloudCannon
-    # telegram: jekyll
     # googleplus: +jekyll
-    # microdotblog: jekyll
+    # instagram: jekyll
     # keybase: jekyll
+    # linkedin: jekyll
+    # microdotblog: jekyll
+    # pinterest: jekyll
+    # telegram: jekyll
+    # youtube_channel_name: CloudCannon
+    # youtube_channel: UC8CXR0-3I70i1tfPg1PAE1g
+    # youtube: jekyll
 
     # Mastodon instances
     # mastodon:
@@ -48,13 +50,10 @@ minima:
     # - username: jekyll2
     #   instance: example.com
 
-# If you want to link only specific pages in your header, uncomment
-# this and add the path to the pages in order as they should show up
+# If you want to link only specific pages in the header, uncomment
+# this and add the path to the pages in order as they should show up.
 #header_pages:
 # - about.md
-
-# Build settings
-theme: minima
 
 plugins:
  - jekyll-feed

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,7 +5,12 @@
 
     <div class="footer-col-wrapper">
       <div class="footer-col">
-        <h2 class="footer-heading">{{ site.title | escape }}</h2>
+        <p class="feed-subscribe">
+          <a href="{{ 'feed.xml' | relative_url }}" title="Subscribe to this feed">
+            <span>Subscribe</span><svg class="svg-icon"><use xlink:href="{{ 'assets/minima-social-icons.svg#rss' | relative_url }}"></use></svg>
+          </a>
+        </p>
+        <h2 class="footer-heading">Contact</h2>
       {%- if site.author %}
         <ul class="contact-list">
           {% if site.author.name -%}

--- a/_includes/social.html
+++ b/_includes/social.html
@@ -18,5 +18,4 @@
   {%- if social.keybase -%}<li><a rel="me" href="https://keybase.io/{{ social.keybase | cgi_escape | escape }}" title="{{ social.keybase | escape }}"><svg class="svg-icon grey"><use xlink:href="{{ '/assets/minima-social-icons.svg#keybase' | relative_url }}"></use></svg></a></li>{%- endif -%}
   {%- if social.microdotblog -%}<li><a rel="me" href="https://micro.blog/{{ social.microdotblog | cgi_escape | escape }}" title="{{ social.microdotblog | escape }}"><svg class="svg-icon grey"><use xlink:href="{{ '/assets/minima-social-icons.svg#microdotblog' | relative_url }}"></use></svg></a></li>{%- endif -%}
   {%- if social.devto -%}<li><a href="https://dev.to/{{ social.devto | cgi_escape | escape }}" title="{{ social.devto | escape }}"><svg class="svg-icon grey"><use xlink:href="{{ '/assets/minima-social-icons.svg#devto' | relative_url }}"></use></svg></a></li>{%- endif -%}
-  {%- if social.rss -%}<li><a href="{{ 'feed.xml' | relative_url }}" title="{{ social.rss | escape }}"><svg class="svg-icon grey"><use xlink:href="{{ '/assets/minima-social-icons.svg#rss' | relative_url }}"></use></svg></a></li>{%- endif -%}
 </ul>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -56,11 +56,6 @@ layout: default
       </div>
     {%- endif %}
 
-    <p class="feed-subscribe">
-      <a href="{{ 'feed.xml' | relative_url }}">
-        <svg class="svg-icon orange"><use xlink:href="{{ 'assets/minima-social-icons.svg#rss' | relative_url }}"></use></svg><span>Subscribe</span>
-      </a>
-    </p>
   {%- endif -%}
 
 </div>

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -222,10 +222,6 @@ pre {
  * Icons
  */
 
-.orange {
-  color: #f66a0a;
-}
-
 .grey {
   color: #828282;
 }

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -128,7 +128,7 @@
 
 .footer-heading {
   @include relative-font-size(1.125);
-  margin-bottom: $spacing-unit / 2;
+  margin-bottom: 0;
 }
 
 .contact-list,


### PR DESCRIPTION
Fix #457 

 - Remove RSS from social icons
 - Move subscribe link in the footer and rename footer-heading
 - remove orange color

### Before

![before-rss](https://user-images.githubusercontent.com/103008/74473666-48ba6680-4ea4-11ea-8e15-0dc09784d0d1.png)

### After

![after-rss](https://user-images.githubusercontent.com/103008/74473663-46f0a300-4ea4-11ea-9dfa-d6098746148a.png)