### PR TITLE
Show tags on posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,6 +53,10 @@ minima:
 #header_pages:
 # - about.md
 
+# If you want that tags on posts link to somewhere, uncomment this and configure
+# the path pattern.
+#taglink: /tags/#:tag
+
 # Build settings
 theme: minima
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,24 +6,42 @@ layout: default
   <header class="post-header">
     <h1 class="post-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
     <p class="post-meta">
-      {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
-      <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
-        {{ page.date | date: date_format }}
-      </time>
-      {%- if page.modified_date -%}
-        ~ 
-        {%- assign mdate = page.modified_date | date_to_xmlschema -%}
-        <time class="dt-modified" datetime="{{ mdate }}" itemprop="dateModified">
-          {{ mdate | date: date_format }}
+      <div class="post-date-and-author">
+        {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+        <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
+          {{ page.date | date: date_format }}
         </time>
-      {%- endif -%}
-      {%- if page.author -%}
-        • {% for author in page.author %}
-          <span itemprop="author" itemscope itemtype="http://schema.org/Person">
-            <span class="p-author h-card" itemprop="name">{{ author }}</span></span>
-            {%- if forloop.last == false %}, {% endif -%}
-        {% endfor %}
-      {%- endif -%}</p>
+        {%- if page.modified_date -%}
+          ~ 
+          {%- assign mdate = page.modified_date | date_to_xmlschema -%}
+          <time class="dt-modified" datetime="{{ mdate }}" itemprop="dateModified">
+            {{ mdate | date: date_format }}
+          </time>
+        {%- endif -%}
+        {%- if page.author -%}
+          • {% for author in page.author %}
+            <span itemprop="author" itemscope itemtype="http://schema.org/Person">
+              <span class="p-author h-card" itemprop="name">{{ author }}</span></span>
+              {%- if forloop.last == false %}, {% endif -%}
+          {% endfor %}
+        {%- endif -%}
+      </div>
+      {% if page.tags.size > 0 %}
+      <div class="post-tags">
+        {%- assign tags = page.tags | sort -%}
+        {%- for tag in tags -%}
+          <span class="post-tag">
+            {%- assign slugified_tag = tag | slugify -%}
+            {%- if site.taglink -%}
+              <a href="{{ site.taglink | replace: ':tag', slugified_tag | relative_url }}">#{{ slugified_tag }}</a>
+            {%- else -%}
+              #{{ slugified_tag }}
+            {%- endif -%}
+          </span>
+        {%- endfor -%}
+      </div>
+      {% endif %}
+    </p>
   </header>
 
   <div class="post-content e-content" itemprop="articleBody">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,7 +5,7 @@ layout: default
 
   <header class="post-header">
     <h1 class="post-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
-    <p class="post-meta">
+    <div class="post-meta">
       <div class="post-date-and-author">
         {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
         <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
@@ -41,7 +41,7 @@ layout: default
         {%- endfor -%}
       </div>
       {% endif %}
-    </p>
+    </div>
   </header>
 
   <div class="post-content e-content" itemprop="articleBody">

--- a/_posts/2016-05-20-welcome-to-jekyll.md
+++ b/_posts/2016-05-20-welcome-to-jekyll.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+tags: [welcome, jekyll, ruby]
 ---
 You’ll find this post in your `_posts` directory. Go ahead and edit it and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run `jekyll serve`, which launches a web server and auto-regenerates your site when a file is updated.
 

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -237,6 +237,10 @@
   margin-bottom: $spacing-unit;
 }
 
+.post-tag {
+  margin-right: $spacing-unit / 2;
+}
+
 .post-title,
 .post-content h1 {
   @include relative-font-size(2.625);


### PR DESCRIPTION
Before:

<img width="787" alt="Screenshot 2020-02-14 at 11 36 51 AM" src="https://user-images.githubusercontent.com/59011975/74499404-85c33f00-4f1e-11ea-8c2a-1c0c16df3626.png">

After:

<img width="764" alt="Screenshot 2020-02-14 at 11 35 05 AM" src="https://user-images.githubusercontent.com/59011975/74499427-98d60f00-4f1e-11ea-9c1c-e730d0680b3b.png">

Besides, the user can configure the path pattern of tag links in `_config.yml`, for example,

```yml
taglink: /tags/#:tag
```

Here is the effect of having links:

<img width="786" alt="Screenshot 2020-02-14 at 11 35 45 AM" src="https://user-images.githubusercontent.com/59011975/74499563-14d05700-4f1f-11ea-9096-b8aa3a3790ed.png">

