### PR TITLE
Adjust margins of headlines to make sections clear

### DIFF
--- a/History.markdown
+++ b/History.markdown
@@ -22,6 +22,7 @@
   * Set margins of hr to improve readability (#461)
   * Export a variable to let users to custom the font family of code (#462)
   * Set margin-bottom of pagination (#458)
+  * Adjust margins of headings to make sections clear (#467)
 
 ### Major Enhancements
 

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -251,6 +251,9 @@
 .post-content {
   margin-bottom: $spacing-unit;
 
+  h1, h2, h3 { margin-top: $spacing-unit * 2 }
+  h4, h5, h6 { margin-top: $spacing-unit }
+
   h2 {
     @include relative-font-size(1.75);
 


### PR DESCRIPTION
This margin style is taken from [`minima-next`](https://github.com/jekyll/minima/pull/294). Since that branch seems will suspend for a long time, I make this PR by just adopting the headline margin style.

Before:

<img width="1440" alt="Screenshot 2020-02-15 at 2 27 14 PM" src="https://user-images.githubusercontent.com/59011975/74583282-74526380-5000-11ea-9519-c258bee9c704.png">

<img width="1436" alt="Screenshot 2020-02-15 at 2 27 48 PM" src="https://user-images.githubusercontent.com/59011975/74583291-8a602400-5000-11ea-861d-c50b1e1beed7.png">

After:

<img width="1440" alt="Screenshot 2020-02-15 at 2 26 00 PM" src="https://user-images.githubusercontent.com/59011975/74583296-92b85f00-5000-11ea-805e-01b8bd7a4dd3.png">

<img width="1437" alt="Screenshot 2020-02-15 at 2 26 21 PM" src="https://user-images.githubusercontent.com/59011975/74583301-a19f1180-5000-11ea-9a25-421354338062.png">
