### PR TITLE
Rename favicons.html to custom-head.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ minima:
 
 ### Extending the `<head />`
 
-You can custom your `head` by creating a file `_includes/custom-head.html` in your source directory, for example, adding favicons:
+You can *add* custom metadata to the `<head />` of your layouts by creating a file `_includes/custom-head.html` in your source directory. For example, to add favicons:
 
 1. Head over to [https://realfavicongenerator.net/](https://realfavicongenerator.net/) to add your own favicons.
 2. [Customize](#customization) default `_includes/custom-head.html` in your source directory and insert the given code snippet.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Refers to snippets of code within the `_includes` directory that can be inserted
   - `footer.html` &mdash; Defines the site's footer section.
   - `google-analytics.html` &mdash; Inserts Google Analytics module (active only in production environment).
   - `head.html` &mdash; Code-block that defines the `<head></head>` in *default* layout.
+  - `custom-head.html` &mdash; Placeholder to allow users to add more metadata to `<head />`.
   - `header.html` &mdash; Defines the site's main header section. By default, pages with a defined `title` attribute will have links displayed here.
   - `social.html` &mdash; Renders social-media icons based on the `minima:social_links` data in the config file.
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ minima:
 ```
 
 
-### Custom head
+### Extending the `<head />`
 
 You can custom your `head` by creating a file `_includes/custom-head.html` in your source directory, for example, adding favicons:
 

--- a/README.md
+++ b/README.md
@@ -184,10 +184,12 @@ minima:
 ```
 
 
-### Add your favicons
+### Custom head
+
+You can custom your `head` by creating a file `_includes/custom-head.html` in your source directory, for example, adding favicons:
 
 1. Head over to [https://realfavicongenerator.net/](https://realfavicongenerator.net/) to add your own favicons.
-2. [Customize](#customization) default `_includes/favicons.html` in your source directory and insert the given code snippet.
+2. [Customize](#customization) default `_includes/custom-head.html` in your source directory and insert the given code snippet.
 
 
 ### Enabling comments (via Disqus)

--- a/_includes/custom-head.html
+++ b/_includes/custom-head.html
@@ -1,5 +1,5 @@
 {% comment %}
-  Placeholder to allow defining custom favicons
+  Placeholder to allow defining custom head, in principle, you can add anything here, e.g. favicons:
 
   1. Head over to https://realfavicongenerator.net/ to add your own favicons.
   2. Customize default _includes/favicons.html in your source directory and insert the given code snippet.

--- a/_includes/custom-head.html
+++ b/_includes/custom-head.html
@@ -2,5 +2,5 @@
   Placeholder to allow defining custom head, in principle, you can add anything here, e.g. favicons:
 
   1. Head over to https://realfavicongenerator.net/ to add your own favicons.
-  2. Customize default _includes/favicons.html in your source directory and insert the given code snippet.
+  2. Customize default _includes/custom-head.html in your source directory and insert the given code snippet.
 {% endcomment %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,11 +2,13 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  {%- include favicons.html -%}
   {%- seo -%}
   <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
   {%- feed_meta -%}
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
     {%- include google-analytics.html -%}
   {%- endif -%}
+
+  {%- include custom-head.html -%}
+  
 </head>


### PR DESCRIPTION
Users may not only want to add favicons in the head but also add anything they want, so rename `favicons.html` to `custom-head.html` can indicate the purpose of the template file.