### PR TITLE
[chore] Normalize Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ rvm:
   - 2.6
   - 2.4
 
-before_install: gem update --system
-install: script/bootstrap
+before_install:
+  - gem update --system --no-document
+  - gem install bundler --no-document
+
 script: script/cibuild
 
 env:
   matrix:
-    - JEKYLL_VERSION="~> 3.5"
-    - JEKYLL_VERSION="~> 3.8.0"
-    - JEKYLL_VERSION=">= 4.0.0.pre.alpha1"
+    - JEKYLL_VERSION="~> 3.8"
+    - JEKYLL_VERSION="~> 4.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 cache: bundler
-rvm:
-  - 2.6
-  - 2.4
+rvm: 2.4
 
 before_install:
   - gem update --system --no-document


### PR DESCRIPTION
- Installing via a shell script was messing with the build cache.
- Jekyll ~> 3.5 is the same as Jekyll ~> 3.8.0.
- Test with just one Ruby version since there isn't any actual Ruby code bundled with the gem (except for the gemspec) that warrants testing with multiple Ruby versions.