### PR TITLE
Specify the font size of the root element

### DIFF
--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -1,3 +1,7 @@
+html {
+  font-size: $base-font-size;
+}
+
 /**
  * Reset some basic elements
  */


### PR DESCRIPTION
Since `relative-font-size` uses `rem`, for avoiding the abnormal size cause by adjusting `base-font-size`, we need to set the font size of the root element to `base-font-size`.