### PR TITLE
Set only the border of the block code

### DIFF
--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -162,7 +162,6 @@ pre,
 code {
   font-family: $code-font-family;
   font-size: 0.9375em;
-  border: 1px solid $brand-color-light;
   border-radius: 3px;
   background-color: $code-background-color;
 }
@@ -172,6 +171,7 @@ code {
 }
 
 pre {
+  border: 1px solid $brand-color-light;
   padding: 8px 12px;
   overflow-x: auto;
 


### PR DESCRIPTION
Eliminating the border of the inline code can make it more fused with the normal text without being obtrusive.

Before:

<img width="757" alt="Screenshot 2020-02-27 at 11 22 42 AM" src="https://user-images.githubusercontent.com/59011975/75409555-01c47a80-5954-11ea-904f-a9892a7ce93c.png">

After:

<img width="764" alt="Screenshot 2020-02-27 at 11 22 11 AM" src="https://user-images.githubusercontent.com/59011975/75409572-0f7a0000-5954-11ea-9f5c-fcf434ae1679.png">
