### PR TITLE
Allow users to select the comments provider

### DIFF
--- a/_includes/disqus_comments.html
+++ b/_includes/disqus_comments.html
@@ -1,17 +1,17 @@
-<div id="disqus_thread"></div>
-<script>
-  var disqus_config = function () {
-    this.page.url = '{{ page.url | absolute_url }}';
-    this.page.identifier = '{{ page.url | absolute_url }}';
-  };
+  <div id="disqus_thread"></div>
+  <script>
+    var disqus_config = function () {
+      this.page.url = '{{ page.url | absolute_url }}';
+      this.page.identifier = '{{ page.url | absolute_url }}';
+    };
 
-  (function() {
-    var d = document, s = d.createElement('script');
+    (function() {
+      var d = document, s = d.createElement('script');
 
-    s.src = 'https://{{ site.disqus.shortname }}.disqus.com/embed.js';
+      s.src = 'https://{{ site.disqus.shortname }}.disqus.com/embed.js';
 
-    s.setAttribute('data-timestamp', +new Date());
-    (d.head || d.body).appendChild(s);
-  })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
+      s.setAttribute('data-timestamp', +new Date());
+      (d.head || d.body).appendChild(s);
+    })();
+  </script>
+  <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/_includes/disqus_comments.html
+++ b/_includes/disqus_comments.html
@@ -1,20 +1,17 @@
-{%- if page.comments != false and jekyll.environment == "production" -%}
+<div id="disqus_thread"></div>
+<script>
+  var disqus_config = function () {
+    this.page.url = '{{ page.url | absolute_url }}';
+    this.page.identifier = '{{ page.url | absolute_url }}';
+  };
 
-  <div id="disqus_thread"></div>
-  <script>
-    var disqus_config = function () {
-      this.page.url = '{{ page.url | absolute_url }}';
-      this.page.identifier = '{{ page.url | absolute_url }}';
-    };
+  (function() {
+    var d = document, s = d.createElement('script');
 
-    (function() {
-      var d = document, s = d.createElement('script');
+    s.src = 'https://{{ site.disqus.shortname }}.disqus.com/embed.js';
 
-      s.src = 'https://{{ site.disqus.shortname }}.disqus.com/embed.js';
-
-      s.setAttribute('data-timestamp', +new Date());
-      (d.head || d.body).appendChild(s);
-    })();
-  </script>
-  <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
-{%- endif -%}
+    s.setAttribute('data-timestamp', +new Date());
+    (d.head || d.body).appendChild(s);
+  })();
+</script>
+<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -30,9 +30,10 @@ layout: default
     {{ content }}
   </div>
 
-  {%- if site.disqus.shortname -%}
-    {%- include disqus_comments.html -%}
-  {%- endif -%}
+  {% if page.comments != false %}
+    {% capture comments_provider %}{{ site.minima.comments_provider | default: "disqus" }}{% endcapture %}
+    {% include {{ comments_provider }}_comments.html %}
+  {% endif %}
 
   <a class="u-url" href="{{ page.url | relative_url }}" hidden></a>
 </article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -30,7 +30,7 @@ layout: default
     {{ content }}
   </div>
 
-  {% if page.comments != false %}
+  {% if page.comments != false and jekyll.environment == "production" %}
     {% capture comments_provider %}{{ site.minima.comments_provider | default: "disqus" }}{% endcapture %}
     {% include {{ comments_provider }}_comments.html %}
   {% endif %}


### PR DESCRIPTION
The users can select their comments provider by configuring:

```yml
minima:
  comments_provider: # Configure the comments provider here (default: disqus)
```

For example, if the comments provider is `discourse`, the user needs to create a file `_includes/discourse_comments.html` and put all script code of `discourse` into that file.

