### PR TITLE
fix: default to having no social_links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,8 +16,8 @@ minima:
 
   # generate social links in footer
   social_links:
-    twitter: jekyllrb
-    github:  jekyll
+    # twitter: jekyllrb
+    # github:  jekyll
     # devto: jekyll
     # dribbble: jekyll
     # facebook: jekyll


### PR DESCRIPTION
## Issue:
Having default social links under the theme configuration file, results in those items showing up, if the user does not override them with their own. 

```
_config.yml
 minima:
   social_links:
     mastodon:
       - username: test
         instance: example.com
```

## Result:

![social-icons-default](https://user-images.githubusercontent.com/2687896/79057762-36905500-7ca8-11ea-9700-a0996842b11e.png)


## Solution:
Removal of default theme social configuration settings to ensure the only social_links are ones the user defines.