### PR TITLE
Adds post reverse features

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ It will be automatically included only when your site contains one or more valid
 
 The title for this section is `Posts` by default and rendered with an `<h2>` tag. You can customize this heading by defining a `list_title` variable in the document's front matter.
 
+Post order can be reversed by configuring `post_order` within `minima` configuration block for site...
+
+```yaml
+minima:
+  post_order: reverse
+```
+
 
 ### Includes
 

--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,7 @@ show_excerpts: false # set to true to show excerpts on the homepage
 # refer to https://shopify.github.io/liquid/filters/date/ if you want to customize this
 minima:
   date_format: "%b %-d, %Y"
+  # post_order: reverse
 
   # generate social links in footer
   social_links:

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -10,8 +10,12 @@ layout: default
   {{ content }}
 
 
-  {% if site.paginate %}
+  {% if site.paginate and site.minima.post_order == 'reverse' %}
+    {% assign posts = paginator.posts | reverse %}
+  {% elsif site.paginate %}
     {% assign posts = paginator.posts %}
+  {% elsif site.minima.post_order == 'reverse' %}
+    {% assign posts = site.posts | reverse %}
   {% else %}
     {% assign posts = site.posts %}
   {% endif %}


### PR DESCRIPTION
This should allow for reversing post order via `_config.yml` configuration.

Test by un-commenting `post_order: reverse` line within `_config.yml` file...

```yml
minima:
  date_format: "%b %-d, %Y"
  post_order: reverse
  # generate social links in footer
  social_links:
    twitter: jekyllrb
    github:  jekyll
    # ...
```


Reversing the order of `paginator.posts` is available too, so the following should be able to test this feature...


```yml
paginate: true

minima:
  date_format: "%b %-d, %Y"
  post_order: reverse
  # generate social links in footer
  social_links:
    twitter: jekyllrb
    github:  jekyll
    # ...
```

Default behavior is unchanged if `post_order` configuration is not present or not assigned to `reverse`.