### PR TITLE
Conditionally load GFM-parser gem in CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ script: script/cibuild
 
 env:
   matrix:
-    - JEKYLL_VERSION="~> 3.8"
+    - JEKYLL_VERSION="~> 3.8.0"
+    - JEKYLL_VERSION="~> 3.9"
     - JEKYLL_VERSION="~> 4.0"

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source "https://rubygems.org"
 gemspec
 
 gem "jekyll", ENV["JEKYLL_VERSION"] if ENV["JEKYLL_VERSION"]
+gem "kramdown-parser-gfm" if ENV["JEKYLL_VERSION"] == "~> 3.9"


### PR DESCRIPTION
So that CI can reliably run with Jekyll 3.8, 3.9 and 4.x