### PR TITLE
Fix for disqus_comments.html

### DIFF
--- a/_includes/disqus_comments.html
+++ b/_includes/disqus_comments.html
@@ -2,11 +2,6 @@
 
   <div id="disqus_thread"></div>
   <script>
-    var disqus_config = function () {
-      this.page.url = '{{ page.url | absolute_url }}';
-      this.page.identifier = '{{ page.url | absolute_url }}';
-    };
-
     (function() {
       var d = document, s = d.createElement('script');
 


### PR DESCRIPTION
Disqus would not load on my blog until I have removed these lines.