### PR TITLE
Replace modified_date with last_modified_at

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -10,9 +10,9 @@ layout: default
       <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
         {{ page.date | date: date_format }}
       </time>
-      {%- if page.modified_date -%}
+      {%- if page.last_modified_at -%}
         ~ 
-        {%- assign mdate = page.modified_date | date_to_xmlschema -%}
+        {%- assign mdate = page.last_modified_at | date_to_xmlschema -%}
         <time class="dt-modified" datetime="{{ mdate }}" itemprop="dateModified">
           {{ mdate | date: date_format }}
         </time>


### PR DESCRIPTION
Since `jekyll-seo-tag` would consider the `last_modified_at` variable.

https://github.com/jekyll/jekyll-seo-tag/blob/38ef0bea229de85f25b5735c432587c09b494398/lib/jekyll-seo-tag/drop.rb#L114