### PR TITLE
Fix theme gemspec

### DIFF
--- a/minima.gemspec
+++ b/minima.gemspec
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 Gem::Specification.new do |spec|
-  spec.name          = "minima"
-  spec.version       = "2.5.0"
-  spec.authors       = ["Joel Glovier"]
-  spec.email         = ["jglovier@github.com"]
+  spec.name     = "minima"
+  spec.version  = "2.5.1"
+  spec.authors  = ["Joel Glovier"]
+  spec.email    = ["jglovier@github.com"]
 
-  spec.summary       = "A beautiful, minimal theme for Jekyll."
-  spec.homepage      = "https://github.com/jekyll/minima"
-  spec.license       = "MIT"
+  spec.summary  = "A beautiful, minimal theme for Jekyll."
+  spec.homepage = "https://github.com/jekyll/minima"
+  spec.license  = "MIT"
 
   spec.metadata["plugin_type"] = "theme"
 


### PR DESCRIPTION
Primarily, this fixes the `spec.version` attribute which was not updated during the last release.
Secondarily, also removes some unnecessary whitespace.