### PR TITLE
FIX: Edit minima/_includes/head.html to include assets/css/style.scss…

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,9 +1,9 @@
 <head>
-  <meta charset="utf-8">
+]  <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {%- seo -%}
-  <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
+  <link rel="stylesheet" href="{{ "/assets/css/style.scss" | relative_url }}">
   {%- feed_meta -%}
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
     {%- include google-analytics.html -%}


### PR DESCRIPTION
FIX: Edited minima/_includes/head.html to include assets/css/style.scss instead of assets/css/style.css, so that the file is actually found when needing to be included.  Sticking with file extension convention for other style sheets within the minima directory.  May or may not fix one or two currently open issues but not sure.