### PR TITLE
Making disqus installation more robust

### DIFF
--- a/_includes/disqus_comments.html
+++ b/_includes/disqus_comments.html
@@ -2,9 +2,14 @@
 
   <div id="disqus_thread"></div>
   <script>
+    var  disqus_url = document.URL;
+    if ('{{ site.url }}') {
+      disqus_url = '{{page.url | absolute_url}}';
+    }
+
     var disqus_config = function () {
-      this.page.url = '{{ page.url | absolute_url }}';
-      this.page.identifier = '{{ page.url | absolute_url }}';
+      this.page.url = disqus_url;
+      this.page.identifier = '{{ page.url }}';
     };
 
     (function() {


### PR DESCRIPTION
Hello

With this PR I'm trying to make Disqus work independently if of your domain URL, in case you don't know it or have to change it.

I had some problems getting Disqus to work on my new site. After some trial error, I found that the problem was that `this.page.url` was not an absolute_url as Disqus needs (https://help.disqus.com/en/articles/1717084-javascript-configuration-variables).

Adding `url:<you prod base URL>` to the Jekyll configuration (`_config.yml`) solved the problem without changing the code, but, as for me, some people might want not to set it.

Also, in the Disqus documentation, they recommend using a `this.page.identifier` that doesn't change if the domain change, to retain the comments in that case. I changed that to be the relative URL (`page.url`). I was tempted to use `page.id` but non-post pages don't have one and the `page.id` is `page.url` without the file extension 

There is an open PR https://github.com/jekyll/minima/pull/536 that could be closed with this one and that shows figuring out the Disqus error is not trivial for normal users.

I'm neither a JS nor Jekyll expert. Any comment or ideas making this code better are welcome! 😃 