### PR TITLE
Corrects image aspect ratio

### DIFF
--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -65,6 +65,7 @@ main {
  */
 img {
   max-width: 100%;
+  height: auto;
   vertical-align: middle;
 }
 


### PR DESCRIPTION
**Edits** `_sass/minima/_base.scss`

Setting CSS of `max-width: 100%;` may be combined with `height: auto;`
which causes image height to shrink if view-port is less than image width.

Note, this may require that image HTML attributes for height
and width be defined, eg...

```html
<img alt-text="Place holder image of a cat"
     width="700"
     height="500"
     src="https://placekitten.com/700/500" />
```