### PR TITLE
Enhance theme to allow switching skins client-side

### DIFF
--- a/_includes/custom-scripts.html
+++ b/_includes/custom-scripts.html
@@ -1,0 +1,3 @@
+{% comment %}
+  Placeholder to allow inserting <script/>s at the end of the page body.
+{% endcomment %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -32,6 +32,25 @@
       {%- include social.html -%}
     </div>
 
+    {%- comment %}
+      The assign expression below needs to be updated whenever a new skin is added.
+      Its less than ideal but since Jekyll doesn't load data files within a theme, there is no
+      better solution.
+      Additionally, the #skin-switch-container below is hidden by default (via CSS).
+      A javascript instruction in the default layout is used to disable the masking CSS to show
+      the element on page and to switch skins. Therefore, browsers with javascript disabled will
+      not show the container element.
+    {% endcomment %}
+    {%- assign skins = 'dark,solarized,solarized-dark' | split: ',' %}
+    <div id="skin-switch-container">
+      This page was rendered with the <select id="skin-switch" onchange="changeSkin()">
+        <option value="style.css">classic</option>
+        {%- for skin in skins %}
+        <option value="{{ skin }}.css">{{ skin }}</option>
+        {%- endfor %}
+      </select> skin of the Minima theme.
+    </div>
+
   </div>
 
 </footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,13 +2,21 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  {%- seo -%}
-  <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
-  {%- feed_meta -%}
+
+  {% seo -%}
+
+  {%- capture stylesheet_url -%}
+  {% if site.minima and site.minima.skin -%}
+  {{ site.minima.skin | prepend: '/assets/css/' | append: '.css' | relative_url }}
+  {%- else -%}
+  {{ '/assets/css/style.css' | relative_url }}
+  {%- endif -%}
+  {% endcapture %}
+  <link id="stylesheet" rel="stylesheet" href="{{ stylesheet_url }}">
+  {% feed_meta %}
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
     {%- include google-analytics.html -%}
   {%- endif -%}
 
   {%- include custom-head.html -%}
-  
 </head>

--- a/_includes/skin.scss
+++ b/_includes/skin.scss
@@ -1,0 +1,3 @@
+@import
+  "minima/skins/{{ page.name }}",
+  "minima/initialize";

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ page.lang | default: site.lang | default: "en" }}">
+<html lang="{{ page.lang | default: site.lang | default: 'en' }}">
 
   {%- include head.html -%}
 
@@ -13,8 +13,21 @@
       </div>
     </main>
 
-    {%- include footer.html -%}
+    {%- include footer.html %}
 
+    <script>
+      document.getElementById("skin-switch-container").style.display = "block";
+      var metaTag = document.getElementById("stylesheet");
+      var SSHref = metaTag.href;
+      var SSName = (SSHref.substring(SSHref.lastIndexOf('/') + 1));
+
+      document.getElementById("skin-switch").value = SSName;
+
+      function changeSkin() {
+        metaTag.href = SSHref.replace(SSName, event.target.value);
+      }
+    </script>
+    {%- include custom-scripts.html -%}
   </body>
 
 </html>

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -142,7 +142,8 @@
 }
 
 .footer-col-wrapper,
-.social-links {
+.social-links,
+#skin-switch-container {
   @include relative-font-size(0.9375);
   color: $brand-color;
 }
@@ -158,6 +159,39 @@
 
 .footer-col-3 {
   width: calc(100% - (#{$spacing-unit} / 2));
+}
+
+.social-media-list {
+  display: table;
+  margin: 0 auto;
+  li {
+    float: left;
+    margin: 5px 10px 5px 0;
+    &:last-of-type { margin-right: 0 }
+    a {
+      display: block;
+      padding: $spacing-unit / 4;
+      border: 1px solid $border-color-01;
+      &:hover { border-color: $border-color-02 }
+    }
+  }
+}
+
+#skin-switch-container {
+  display: none;
+  max-width: 400px;
+  margin: 0 auto;
+  padding: $spacing-unit / 2;
+  text-align: center;
+  select {
+    margin: 0 2px;
+    padding: 5px 2px;
+    border-color: $border-color-02;
+    border-radius: 0;
+    &:focus-visible {
+      outline: none;
+    }
+  }
 }
 
 @media screen and (min-width: $on-large) {
@@ -283,23 +317,6 @@
   }
   h6 {
     @include relative-font-size(1.0625);
-  }
-}
-
-
-.social-media-list {
-  display: table;
-  margin: 0 auto;
-  li {
-    float: left;
-    margin: 5px 10px 5px 0;
-    &:last-of-type { margin-right: 0 }
-    a {
-      display: block;
-      padding: $spacing-unit / 4;
-      border: 1px solid $border-color-01;
-      &:hover { border-color: $border-color-02 }
-    }
   }
 }
 

--- a/assets/css/dark.scss
+++ b/assets/css/dark.scss
@@ -1,0 +1,4 @@
+---
+---
+
+{% include skin.scss %}

--- a/assets/css/solarized-dark.scss
+++ b/assets/css/solarized-dark.scss
@@ -1,0 +1,4 @@
+---
+---
+
+{% include skin.scss %}

--- a/assets/css/solarized.scss
+++ b/assets/css/solarized.scss
@@ -1,0 +1,4 @@
+---
+---
+
+{% include skin.scss %}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -3,5 +3,5 @@
 ---
 
 @import
-  "minima/skins/{{ site.minima.skin | default: 'classic' }}",
+  "minima/skins/classic",
   "minima/initialize";


### PR DESCRIPTION
## Key points

- Generate a complete CSS file for each skin:
  - `assets/css/style.css` (default stylesheet / *classic* skin)
  - `assets/css/dark.css` (*dark* skin)
  - `assets/css/solarized.css` (*solarized* skin)
  - `assets/css/solarized-dark.css` (*solarized-dark* skin)
- Use javascript to render a `<select/>` element in the site-footer **to allow switching stylesheets on a deployed site**.
- Introduce `custom-scripts.html` placeholder to allow adding more scripts before the closing `</body>` tag.

---

Live Demo: https://ashmaroli.github.io/minima/