### PR TITLE
Added system-ui as a cross-platform default font

### DIFF
--- a/_sass/minima/initialize.scss
+++ b/_sass/minima/initialize.scss
@@ -2,7 +2,7 @@
 
 // Define defaults for each variable.
 
-$base-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Segoe UI Symbol", "Segoe UI Emoji", "Apple Color Emoji", Roboto, Helvetica, Arial, sans-serif !default;
+$base-font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Segoe UI Symbol", "Segoe UI Emoji", "Apple Color Emoji", Roboto, Helvetica, Arial, sans-serif !default;
 $code-font-family: "Menlo", "Inconsolata", "Consolas", "Roboto Mono", "Ubuntu Mono", "Liberation Mono", "Courier New", monospace;
 $base-font-size:   16px !default;
 $base-font-weight: 400 !default;


### PR DESCRIPTION
This is what happens on Linux when Segoe UI Emoji is available, but Segoe UI isn't:

![minima-before](https://user-images.githubusercontent.com/246061/135750067-8d302191-1fe8-4b77-9cd6-62019e34816d.png)

`system-ui` is provided by modern browsers as [a cross-platform default font](https://caniuse.com/font-family-system-ui). This is how it looks with `system-ui` in the font list:

![minima-after](https://user-images.githubusercontent.com/246061/135750215-bd313d53-f14a-4428-9775-d9ff8b6a6963.png)

It was a controversial choice back in 2017. because it did not address i18n well and therefore it was removed from Bootstrap twbs/bootstrap#22377. However, it was added back in v5 twbs/bootstrap#30561.