### PR TITLE
Improve CI workflow configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,21 +1,25 @@
-name: "Build"
-on: [push]
+name: Continuous Integration
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: "Test with Jekyll ${{ matrix.jekyll }}"
+    runs-on: "ubuntu-latest"
     strategy:
       matrix:
         jekyll: ["~> 3.9", "~> 4.2"]
+    env:
+      JEKYLL_VERSION: ${{ matrix.jekyll }}
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.5
-      - name: 'Install dependencies'
-        run: bundle install
-        env: 
-          JEKYLL_VERSION: ${{ matrix.jekyll }}
-      - name: 'Run tests'
+          bundler-cache: true
+      - name: Run tests
         run: script/cibuild
-        env: 
-          JEKYLL_VERSION: ${{ matrix.jekyll }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,10 @@ jobs:
     env:
       JEKYLL_VERSION: ${{ matrix.jekyll }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Set Up Ruby 2.5
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.5
           bundler-cache: true


### PR DESCRIPTION
Follow-up to #608

- Trigger workflow for `pull_request` event as well.
- Improve job name in statuses.
- Set env once for all steps.
- Run `bundle install` as part of `setup-ruby` action.