### PR TITLE
Build and deploy demo site via GH Action workflow

### DIFF
--- a/.github/workflows/demo_site.yml
+++ b/.github/workflows/demo_site.yml
@@ -1,0 +1,53 @@
+name: Build and Deploy Demo Site
+
+on:
+  push:
+    branches:
+      - master
+      - demo-site
+
+env:
+  RUBY_VERSION: 2.7
+
+jobs:
+  deploy_demo_site:
+    runs-on: "ubuntu-latest"
+    env:
+      BUNDLE_PATH: "vendor/bundle"
+      BUNDLE_JOBS: 4
+      BUNDLE_RETRY: 3
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          repository: jekyll/minima
+          ref: demo-site
+      - name: Set up Ruby 2.7
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - name: Clone target branch
+        run: |
+          REMOTE_BRANCH="${REMOTE_BRANCH:-gh-pages}"
+          REMOTE_REPO="https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
+
+          echo "Publishing to ${GITHUB_REPOSITORY} on branch ${REMOTE_BRANCH}"
+          rm -rf _site/
+          git clone --depth=1 --branch="${REMOTE_BRANCH}" --single-branch --no-checkout "${REMOTE_REPO}" _site/
+      - name: Build site
+        run: bundle exec jekyll build --verbose --trace
+      - name: Deploy to GitHub Pages
+        run: |
+          SOURCE_COMMIT="$(git log -1 --pretty="%an: %B" "$GITHUB_SHA")"
+          pushd _site &>/dev/null
+          : > .nojekyll
+
+          git add --all
+          git -c user.name="${GITHUB_ACTOR}" -c user.email="${GITHUB_ACTOR}@users.noreply.github.com" \
+            commit --quiet \
+            --message "Deploy demo-site from ${GITHUB_SHA}" \
+            --message "$SOURCE_COMMIT"
+          git push
+
+          popd &>/dev/null


### PR DESCRIPTION
## Summary

Use source files in branch `demo-site` to build demo site and deploy via GitHub Pages.

A separate branch allows *customizing source dir contents* without affecting theme.
Though this does include a small amount of duplication (w.r.t Markdown source files), the changes to them will probably be so small that maintainers can manually cherry-pick to the `demo-site` branch. 

## Context

https://github.com/jekyll/minima/pull/601#issuecomment-1002753354

Closes #601 
