### PR TITLE
change base-font-family sequence

### DIFF
--- a/_sass/minima/initialize.scss
+++ b/_sass/minima/initialize.scss
@@ -2,7 +2,7 @@
 
 // Define defaults for each variable.
 
-$base-font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Segoe UI Symbol", "Segoe UI Emoji", "Apple Color Emoji", Roboto, Helvetica, Arial, sans-serif !default;
+$base-font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Segoe UI Emoji", "Segoe UI Symbol", "Apple Color Emoji", Roboto, Helvetica, Arial, sans-serif !default;
 $code-font-family: "Menlo", "Inconsolata", "Consolas", "Roboto Mono", "Ubuntu Mono", "Liberation Mono", "Courier New", monospace;
 $base-font-size:   16px !default;
 $base-font-weight: 400 !default;


### PR DESCRIPTION
Resolves #653

Restore the emoji color in edge/chrome browsers in windows system. change base-font-family sequence, i.e. putting the "Segoe UI Emoji" before "Segoe UI Symbol"