### PR TITLE
Remove default twitter and github links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,8 +16,8 @@ minima:
 
   # generate social links in footer
   social_links:
-    twitter: jekyllrb
-    github:  jekyll
+    # twitter: jekyllrb
+    # github:  jekyll
     # devto: jekyll
     # dribbble: jekyll
     # facebook: jekyll


### PR DESCRIPTION
This will not please the demo website but now it means that anyone using Minima gets to disable Twitter and GitHub social links.
Closes #664 