### PR TITLE
Footer: support RSS feed path (jekyll-feed plugin)

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
     <div class="footer-col-wrapper">
       <div class="footer-col">
         <p class="feed-subscribe">
-          <a href="{{ 'feed.xml' | relative_url }}">
+          <a href="{{ site.feed.path | default: 'feed.xml' | relative_url }}">
             <svg class="svg-icon orange">
               <use xlink:href="{{ 'assets/minima-social-icons.svg#rss' | relative_url }}"></use>
             </svg><span>Subscribe</span>


### PR DESCRIPTION
(This is my first commit and PR on this repo. Please feel free to reject or edit it as you see fit. Thanks!)

The jekyll-feed plugin supports an optional user-defined [RSS feed path](https://github.com/jekyll/jekyll-feed#already-have-a-feed-path). `jekyll-feed` uses that path to generate the RSS autodiscovery meta tag. This changes minima to honor that feed path when it is defined.