### PR TITLE
Fix deprecation warnings from Dart Sass

### DIFF
--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -43,7 +43,7 @@ h1, h2, h3, h4, h5, h6,
 p, blockquote, pre,
 ul, ol, dl, figure,
 %vertical-rhythm {
-  margin-bottom: $spacing-unit / 2;
+  margin-bottom: $spacing-unit * .5;
 }
 
 hr {
@@ -140,7 +140,7 @@ a {
 blockquote {
   color: $brand-color;
   border-left: 4px solid $border-color-01;
-  padding-left: $spacing-unit / 2;
+  padding-left: $spacing-unit * .5;
   @include relative-font-size(1.125);
   font-style: italic;
 
@@ -201,8 +201,8 @@ pre {
   max-width: calc(#{$content-width} - (#{$spacing-unit}));
   margin-right: auto;
   margin-left: auto;
-  padding-right: $spacing-unit / 2;
-  padding-left: $spacing-unit / 2;
+  padding-right: $spacing-unit * .5;
+  padding-left: $spacing-unit * .5;
   @extend %clearfix;
 
   @media screen and (min-width: $on-large) {
@@ -262,7 +262,7 @@ table {
     }
   }
   th, td {
-    padding: ($spacing-unit / 3) ($spacing-unit / 2);
+    padding: ($spacing-unit * 33.3333333333 * .01) ($spacing-unit * .5);
   }
   th {
     background-color: $table-header-bg-color;

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -31,7 +31,7 @@
 .site-nav {
   position: absolute;
   top: 9px;
-  right: $spacing-unit / 2;
+  right: $spacing-unit * .5;
   background-color: $background-color;
   border: 1px solid $border-color-01;
   border-radius: 5px;
@@ -128,7 +128,7 @@
 
 .footer-heading {
   @include relative-font-size(1.125);
-  margin-bottom: $spacing-unit / 2;
+  margin-bottom: $spacing-unit * .5;
 }
 
 .feed-subscribe .svg-icon {
@@ -148,7 +148,7 @@
 }
 
 .footer-col {
-  margin-bottom: $spacing-unit / 2;
+  margin-bottom: $spacing-unit * .5;
 }
 
 .footer-col-1,
@@ -181,16 +181,16 @@
 
   .footer-col {
     width: calc(100% - (#{$spacing-unit} / 2));
-    padding: 0 ($spacing-unit / 2);
+    padding: 0 ($spacing-unit * .5);
 
     &:first-child {
-      padding-right: $spacing-unit / 2;
+      padding-right: $spacing-unit * .5;
       padding-left: 0;
     }
 
     &:last-child {
       padding-right: 0;
-      padding-left: $spacing-unit / 2;
+      padding-left: $spacing-unit * .5;
     }
   }
 }
@@ -318,7 +318,7 @@
     }
     div {
       display: block;
-      padding: $spacing-unit / 4;
+      padding: $spacing-unit * .25;
       border: 1px solid transparent;
 
       &.pager-edge {


### PR DESCRIPTION
```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
```

However, `math.div` is not supported by `sass` or `sassc` used in older version of jekyll-sass-converter. Therefore this PR fixes it in a backward compatible way by replaceing ` / 2` with ` * .5`, and replacing ` / 3` with ` * 33.3333333333 * .01` (a hack for precision in Sass). The css output is exactly same as before.

- Fixes #699

@ashmaroli 