### PR TITLE
upgrade using sass-migrator division **/*.scss

### DIFF
--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -1,3 +1,5 @@
+@use "sass:list";
+
 html {
   font-size: $base-font-size;
 }
@@ -19,7 +21,7 @@ dl, dd, ol, ul, figure {
  * Basic styling
  */
 body {
-  font: $base-font-weight #{$base-font-size}/#{$base-line-height} $base-font-family;
+  font: $base-font-weight list.slash($base-font-size, $base-line-height) $base-font-family;
   color: $text-color;
   background-color: $background-color;
   -webkit-text-size-adjust: 100%;


### PR DESCRIPTION
SASS is deprecating the ability to use a `/` (slash) for division. See the documentation [here](https://sass-lang.com/documentation/breaking-changes/slash-div#automatic-migration).  

Per the documentation, use [Automatic Migration](https://sass-lang.com/documentation/breaking-changes/slash-div#automatic-migration) with the following code:

```
npm install -g sass-migrator
sass-migrator division **/*.scss
```

I ran this code in the `_sass` folder. One line was added, and one line was modified. DART SASS warnings no longer appear.