### PR TITLE
Trigger demo-site build manually

### DIFF
--- a/.github/workflows/demo_site.yml
+++ b/.github/workflows/demo_site.yml
@@ -1,10 +1,8 @@
 name: Build and Deploy Demo Site
 
 on:
-  push:
-    branches:
-      - master
-      - demo-site
+  # Run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   deploy_demo_site:


### PR DESCRIPTION
Since automatic builds off `master` fails when triggered post a pull-request merge.