### PR TITLE
add `mastodon` to social-media platforms in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ The theme ships with an icon for `rss` and icons of select social-media platform
 - `instagram`
 - `keybase`
 - `linkedin`
+- `mastodon`
 - `microdotblog`
 - `pinterest`
 - `stackoverflow`

--- a/_config.yml
+++ b/_config.yml
@@ -62,6 +62,7 @@ minima:
   #  - { platform: instagram,      user_url: "https://www.instagram.com/jekyll" }
   #  - { platform: keybase,        user_url: "https://keybase.io/jekyll" }
   #  - { platform: linkedin,       user_url: "https://www.linkedin.com/in/jekyll" }
+  #  - { platform: mastodon,       user_url: "https://mastodon.social/@jekyll" }
   #  - { platform: microdotblog,   user_url: "https://micro.blog/jekyll" }
   #  - { platform: pinterest,      user_url: "https://www.pinterest.com/jekyll" }
   #  - { platform: stackoverflow,  user_url: "https://stackoverflow.com/users/1234567/jekyll" }


### PR DESCRIPTION
I noticed the `.svg` was added already but Mastodon not listed under the social-media platforms in the README. This is a minor thing but might help new users to know it's there 👀 