### PR TITLE
Avoid clipping responsive social SVG icons

### DIFF
--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -243,6 +243,7 @@ pre {
   display: inline-block;
   fill: currentColor;
   vertical-align: text-bottom;
+  overflow: visible;
 }
 
 


### PR DESCRIPTION
After #677 , social icons slightly clips, probably due to issues similar to https://gsap.com/community/forums/topic/16844-svg-overflowing-its-bounding-box-while-scaling/

For example, see the right edge of the GitHub icon 
<img width="173" alt="image" src="https://github.com/user-attachments/assets/bb8e82a4-7590-4ed7-a874-5492455fcf7f">

The CSS property added in this PR fixes it.
<img width="285" alt="image" src="https://github.com/user-attachments/assets/0f0f34de-98e6-41b5-9c82-bcf31ec7ca92">
