### PR TITLE
Fix Google Analytics script

### DIFF
--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,6 +1,5 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
 <script>
-  window['ga-disable-{{ site.google_analytics }}'] = window.doNotTrack === "1" || navigator.doNotTrack === "1" || navigator.doNotTrack === "yes" || navigator.msDoNotTrack === "1";
   window.dataLayer = window.dataLayer || [];
   function gtag(){window.dataLayer.push(arguments);}
   gtag('js', new Date());


### PR DESCRIPTION
## Context

Adapted from patch #824 for `2.5-stable` branch by @iTiamo

## Reference

https://github.com/jekyll/minima/issues/816#issuecomment-2497302453 : 

> creating a file called `google-analytics` in my local directory `_includes` with the snippet that was provided to me...
> ```html
><!-- Google tag (gtag.js) -->
><script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
><script>
>  window.dataLayer = window.dataLayer || [];
>  function gtag(){dataLayer.push(arguments);}
>  gtag('js', new Date());
>
>  gtag('config', '{{ site.google_analytics }}');
></script>
>```
>
> This caused data to start flowing into my Google Analytics instance.