### PR TITLE
Move `show_excerpts` setting to be under `minima` namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,10 +315,12 @@ Google Analytics will only appear in production, i.e., `JEKYLL_ENV=production`
 
 ### Enabling Excerpts on the Home Page
 
-To display post-excerpts on the Home Page, simply add the following to your `_config.yml`:
+To display post-excerpts on the Home Page, simply set `show_excepts` under top-level key `minima` to `true` in your
+`_config.yml`:
 
 ```yaml
-show_excerpts: true
+minima:
+  show_excerpts: true
 ```
 
 

--- a/_config.yml
+++ b/_config.yml
@@ -31,9 +31,6 @@ plugins:
 header_pages:
   - about.md
 
-# Set to `true` to show excerpts on the homepage.
-#show_excerpts: false
-
 # Minima specific settings, which are only available from Minima 3.0 onward.
 minima:
   # Minima skin selection.
@@ -45,7 +42,10 @@ minima:
   # solarized-dark	   Dark variant of solarized color scheme.
   # solarized	         Adaptive skin for solarized color scheme skins.
   skin: classic
-  
+
+  # Set to `true` to show excerpts on the homepage.
+  #show_excerpts: false
+
   # Minima date format.
   # The default value is "%b %d, %Y" (e.g. Nov 14, 2023) 
   # Refer to https://shopify.github.io/liquid/filters/date/ if you want to customize this.

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -31,7 +31,7 @@ layout: base
             {{ post.title | escape }}
           </a>
         </h3>
-        {%- if site.show_excerpts -%}
+        {%- if site.minima.show_excerpts -%}
           {{ post.excerpt }}
         {%- endif -%}
       </li>


### PR DESCRIPTION
`show_excerpts` is not a configuration key defined by Jekyll. So move it to be under the `minima` namespace.