### PR TITLE
Add optional fa_icon_pack property to social_links to allow more Font Awesome icons packs beyond brands

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,10 +294,16 @@ minima:
     - title: Jekyll at X (formerly Twitter)
       icon: x-twitter
       url: "https://x.com/jekyllrb"
+    - title: Email Jekyll
+      icon: envelope
+      fa_icon_pack: regular
+      url: "mailto:jekyll@example.com"
 ```
-
-where `title` corresponds to the link-title displayed when a visitor hovers mouse-pointer over url / icon and
-`icon` refers to the Font Awesome icon id. e.g. `github` corresponds to `fa-github`.
+Properties:
+- `title` corresponds to the link-title displayed when a visitor hovers mouse-pointer over url / icon
+- `icon` refers to the Font Awesome icon id, e.g. `github` corresponds to `fa-github`
+- `fa_icon_pack` (optional) defines the Font Awesome icon pack. Default value is `brands`, which corresponds to `fa-brands`
+- `url` url of the social link
 
 Social platform icons are rendered using the latest version of Font Awesome Free webfonts sourced via remote CDN.
 The full list of available social icons can be found at https://fontawesome.com/search?ic=brands

--- a/_includes/social.html
+++ b/_includes/social.html
@@ -2,7 +2,7 @@
 {%- for entry in site.minima.social_links -%}
   <li>
     <a rel="me" href="{{ entry.url }}" target="_blank" title="{{ entry.title }}">
-      <span class="grey fa-brands fa-{{ entry.icon }} fa-lg"></span>
+      <span class="grey fa-{{ entry.fa_icon_pack | default: "brands" }} fa-{{ entry.icon }} fa-lg"></span>
     </a>
   </li>
 {%- endfor -%}


### PR DESCRIPTION
# Summary
Extends functionality introduced in #839. Proposal for my issue raised here: #843

# Interface changes
Adds an optional property to the config keys under minima:social_links. Will not break existing configurations.

# Motivation
Allow users to use icons from Font Awesome beyond the brands icon pack in their social links.