### PR TITLE
Silence Jekyll build warning concerning logger dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,9 @@ gemspec
 
 gem "jekyll", ENV["JEKYLL_VERSION"] if ENV["JEKYLL_VERSION"]
 gem "kramdown-parser-gfm" if ENV["JEKYLL_VERSION"] == "~> 3.9"
+
+# Include logger (no-longer included by default from Ruby 3.5.0 onward).
+# WARNING: logger was loaded from the standard library, but will no longer be
+# part of the default gems starting from Ruby 3.5.0.
+# You can add logger to your Gemfile or gemspec to silence this warning.
+gem 'logger', '~> 1.6', '>= 1.6.5'

--- a/minima.gemspec
+++ b/minima.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jekyll", ">= 3.5", "< 5.0"
   spec.add_runtime_dependency "jekyll-feed", "~> 0.9"
   spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.1"
+  spec.add_runtime_dependency "logger", "~> 1.6", ">= 1.6.5"
 end


### PR DESCRIPTION
WARNING: "logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0. You can add logger to your Gemfile or gemspec to silence this warning.