### PR TITLE
Simplify `.wrapper` style definition

### DIFF
--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -198,18 +198,10 @@ pre {
  * Wrapper
  */
 .wrapper {
-  max-width: calc(#{$content-width} - (#{$spacing-unit}));
-  margin-right: auto;
-  margin-left: auto;
-  padding-right: $spacing-unit * .5;
-  padding-left: $spacing-unit * .5;
+  max-width: $content-width;
+  margin: 0 auto;
+  padding: 0 $spacing-unit;
   @extend %clearfix;
-
-  @media screen and (min-width: $on-large) {
-    max-width: calc(#{$content-width} - (#{$spacing-unit} * 2));
-    padding-right: $spacing-unit;
-    padding-left: $spacing-unit;
-  }
 }
 
 


### PR DESCRIPTION
- max-width of **child elements** of `.wrapper` now equals `$content-width` &mdash; no more complicated math needed to determine width of *content text*.
- consistent padding at all viewport sizes.