### PR TITLE
Simplify inserting markup before closing body tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Refers to snippets of code within the `_includes` directory that can be inserted
   - `header.html` &mdash; Defines the site's main header section. By default, pages with a defined `title` attribute will have links displayed here.
   - `social.html` &mdash; Renders social-media icons based on the `minima:social_links` data in the config file using
     the latest version of Font Awesome Free webfonts via remote CDN.
+  - `sub-footer.html` &mdash; Placeholder to allow inserting markup (e.g. deferred scripts) before the `</body>` tag.
 
 
 ### Sass

--- a/_includes/sub-footer.html
+++ b/_includes/sub-footer.html
@@ -1,0 +1,4 @@
+{% comment %}
+  Use this to insert markup before the closing body tag.
+  For example, scripts that need to be executed after the document has finished loading.
+{% endcomment %}

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -15,6 +15,8 @@
 
     {%- include footer.html -%}
 
+    {%- include sub-footer.html -%}
+
   </body>
 
 </html>


### PR DESCRIPTION
Introduce new inclusion / include_file named `sub-footer.html` to allow inserting markup before the closing `</body>` tag.
- No need to customize `_layouts/base.html`.
- No need to customize `_includes/footer.html`.