### PR TITLE
Improve rendering of post header

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,25 +5,31 @@ layout: base
 
   <header class="post-header">
     <h1 class="post-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
-    <p class="post-meta">
+    <div class="post-meta">
       {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
-      <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
+      {% assign pdate = page.date | date_to_xmlschema %}
+      {%- if page.modified_date %}<span class="meta-label">Published:</span>{% endif %}
+      <time class="dt-published" datetime="{{ pdate }}" itemprop="datePublished">
         {{ page.date | date: date_format }}
       </time>
       {%- if page.modified_date -%}
-        ~ 
-        {%- assign mdate = page.modified_date | date_to_xmlschema -%}
+        <span class="bullet-divider">•</span>
+        <span class="meta-label">Updated:</span>
+        {%- assign mdate = page.modified_date | date_to_xmlschema %}
         <time class="dt-modified" datetime="{{ mdate }}" itemprop="dateModified">
           {{ mdate | date: date_format }}
         </time>
       {%- endif -%}
-      {%- if page.author -%}
-        • {% for author in page.author %}
+      {%- if page.author %}
+      <div class="{% unless page.modified_date %}force-inline {% endunless %}post-authors">
+        {%- for author in page.author %}
           <span itemprop="author" itemscope itemtype="http://schema.org/Person">
             <span class="p-author h-card" itemprop="name">{{ author }}</span></span>
-            {%- if forloop.last == false %}, {% endif -%}
+          {%- if forloop.last == false %}, {% endif -%}
         {% endfor %}
-      {%- endif -%}</p>
+      </div>
+      {%- endif %}
+    </div>
   </header>
 
   <div class="post-content e-content" itemprop="articleBody">

--- a/_posts/2016-05-20-my-example-post.md
+++ b/_posts/2016-05-20-my-example-post.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+author: John Doe
 ---
 
 Eos eu docendi tractatos sapientem, brute option menandri in vix, quando vivendo accommodare te ius. Nec melius fastidii constituam id, viderer theophrastus ad sit, hinc semper periculis cum id. Noluisse postulant assentior est in, no choro sadipscing repudiandae vix. Vis in euismod delenit dignissim. Ex quod nostrum sit, suas decore animal id ius, nobis solet detracto quo te.

--- a/_posts/2016-05-20-this-post-demonstrates-post-content-styles.md
+++ b/_posts/2016-05-20-this-post-demonstrates-post-content-styles.md
@@ -6,6 +6,7 @@ author:
 - Bart Simpson
 - Nelson Mandela Muntz
 meta: "Springfield"
+modified_date: 2016-05-27
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce bibendum neque eget nunc mattis eu sollicitudin enim tincidunt. Vestibulum lacus tortor, ultricies id dignissim ac, bibendum in velit.

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -239,10 +239,29 @@
  */
 .post-header {
   margin-bottom: $spacing-unit;
+  padding-bottom: 18px;
+  text-align: center;
+  border-bottom: 1px solid $border-color-01;
 }
+
+.post-meta {
+  .bullet-divider { padding-inline: 15px }
+  .meta-label { font-weight: 600 }
+
+  .force-inline {
+    display: inline;
+    &::before {
+      content: "•";
+      padding-inline: 5px;
+    }
+  }
+  .post-authors { margin-top: 3px }
+}
+
 
 .post-title,
 .post-content h1 {
+  margin-bottom: 10px;
   @include relative-font-size(2.625);
   letter-spacing: -1px;
   line-height: 1.15;


### PR DESCRIPTION
## Summary

- Align post title to center of header
- Render post author(s) in the succeeding line *if `page.modified_date` is defined*.
- Render labels to distinguish *published date* and *modified date*.

## Samples

### Before

![2016_05_20_this-post-demonstrates-post-content-styles](https://github.com/user-attachments/assets/974efc19-b67c-4115-ae36-dcb49d13c590)
![2016_05_20_my-example-post](https://github.com/user-attachments/assets/05beb0cf-3323-4557-98b1-9d2e6adb83b5)

### After

![2016_05_20_this-post-demonstrates-post-content-styles](https://github.com/user-attachments/assets/904c4050-d86a-45b5-b0fa-b10227983e46)
![2016_05_20_my-example-post](https://github.com/user-attachments/assets/1cd9313d-715f-435d-878f-eb2e0c2b341e)

