### PR TITLE
Improve link underline styling

### DIFF
--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -121,7 +121,8 @@ a {
 
   &:hover {
     color: $link-hover-color;
-    text-decoration: underline;
+    text-decoration: underline $brand-color;
+    text-underline-offset: 3px;
   }
 
   .social-media-list &:hover {


### PR DESCRIPTION
- Add an offset between glyph and underline
- Render underline with `$brand-color` instead of `$link-hover-color`.

### Before

![underline-before](https://github.com/user-attachments/assets/296aa14d-6207-41de-99db-1fe2b8ab0276)

### After

![underline-after](https://github.com/user-attachments/assets/bf187b3a-a470-440c-baa4-65642b33e5b8)
