### PR TITLE
Completely use pdate var in layout/post.html

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -10,7 +10,7 @@ layout: base
       {% assign pdate = page.date | date_to_xmlschema %}
       {%- if page.modified_date %}<span class="meta-label">Published:</span>{% endif %}
       <time class="dt-published" datetime="{{ pdate }}" itemprop="datePublished">
-        {{ page.date | date: date_format }}
+        {{ pdate | date: date_format }}
       </time>
       {%- if page.modified_date -%}
         <span class="bullet-divider">•</span>


### PR DESCRIPTION
When I merging the minima branch of my site, I noticed the post layout used `pdate` as a variable, but it was only used once.\
There still was a `page.date` that wasn't replaced.