### PR TITLE
Add a warning regarding HEAD commit of `master`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > 
 > While you may use this theme in the current state either via the `jekyll-remote-theme` plugin or via a Gemfile, it is
 > recommended to point to a particular git ref that does not break your site's existing render and gradually update to a
-> newer git ref via a pull request.
+> newer git ref via a pull request after consulting this repository's commit-log and README.
 >
 > **Pointing directly to the `HEAD` commit of the `master` branch is risky and may contain changes that break your site.** 
 >


### PR DESCRIPTION
Since not everyone may be aware of the risks of pointing directly at HEAD commit during semver-major development-in-progress and how to safely consume breaking changes.

*TODO: Remove this warning prior to releasing v3.0.0 gem.*