### PR TITLE
Reduce wrapper padding on small screens

### DIFF
--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -203,6 +203,11 @@ pre {
   margin: 0 auto;
   padding: 0 $spacing-unit;
   @extend %clearfix;
+
+  @media screen and (max-width: $on-medium) {
+    padding-right: $spacing-unit * 0.6;
+    padding-left: $spacing-unit * 0.6;
+  }
 }
 
 

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -31,7 +31,7 @@
 .site-nav {
   position: absolute;
   top: 9px;
-  right: $spacing-unit * .5;
+  right: $spacing-unit * 0.6;
   background-color: $background-color;
   border: 1px solid $border-color-01;
   border-radius: 5px;


### PR DESCRIPTION
Make better use of limited view-space on small screens.
Was `15px !default` in v2.5.
Is currently `30px !default` on `master`.

Now it will be `18px !default`.