### PR TITLE
Set default `font-weight` of headings to `500`

### DIFF
--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -104,7 +104,7 @@ li {
  */
 h1, h2, h3, h4, h5, h6 {
   color: $heading-color;
-  font-weight: $base-font-weight;
+  font-weight: 500;
 }
 
 

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -276,6 +276,7 @@
 .post-content h1 {
   margin-bottom: 10px;
   @include relative-font-size(2.625);
+  font-weight: $base-font-weight;
   letter-spacing: -1px;
   line-height: 1.15;
 


### PR DESCRIPTION
But retain existing style for `.post-title`.