### PR TITLE
Refresh styling of highlighted code snippet blocks

### DIFF
--- a/_posts/2016-05-19-codeblocks-ahoy.md
+++ b/_posts/2016-05-19-codeblocks-ahoy.md
@@ -1,0 +1,99 @@
+---
+layout: post
+---
+
+An article with various blocks of highlighted code snippets.
+
+```ruby
+=begin
+  Dummy class nested inside a dummy module
+  Private API
+=end
+```
+```diff
+- This line is redacted
+- This line has been deleted
++ This line is visible
++ This line has been inserted
+This line has not been changed
+```
+```sass
+@import "base"
+
+.card
+  display: inline-block
+  margin: 0
+  padding: 0
+
+  &:hover
+    color: #ab45ef;
+```
+```ruby
+21 + 54 = 0
+foo ||= bar
+foo / bar
+
+24
+45.75
+0x2C716
+\x0A
+01010
+
+/ya?ml/
+"yaml"
+```
+```ruby
+include Enumerable
+
+module Foo
+  class Bar
+    LIPSUM = "lorem ipsum dolor sit"
+
+    attr_reader :layout
+
+    def initialize
+      @layout = Layout.new
+    end
+
+    # instance method
+    def profile
+      measure_time do
+        compile layout
+        layout.render_with Bar::LIPSUM
+      end
+    rescue ArgumentError
+      false
+    end
+  end
+end
+
+# Execute code
+Foo::Bar.new.profile
+```
+
+{% raw %}
+```liquid
+{% assign foo = page.foo | bar: 'baz' %}
+{{ foo }}
+```
+{% endraw %}
+
+```yaml
+author:
+  admin: true
+  name: John Doe
+  email: johndoe@example.com
+  id: 75636474
+```
+
+{% highlight html linenos %}
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Hello World</title>
+  </head>
+  <body>
+    <p>Hello, World!</p>
+  </body>
+</html>
+{% endhighlight %}

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -163,35 +163,49 @@ blockquote {
 pre,
 code {
   font-family: $code-font-family;
-  font-size: 0.9375em;
-  border: 1px solid $border-color-01;
-  border-radius: 3px;
   background-color: $code-background-color;
-}
 
-code {
-  padding: 1px 5px;
+  @include media-query($on-palm) {
+    font-family: monospace;
+  }
 }
 
 pre {
   padding: 8px 12px;
+  font-size: 15px;
+  line-height: 1.4;
+  color: $heading-color;
   overflow-x: auto;
 
   > code {
-    border: 0;
-    padding-right: 0;
-    padding-left: 0;
+    display: inline-block;
+    width: 100%;
   }
 }
 
-.highlight {
-  border-radius: 3px;
-  background: $code-background-color;
+div.highlight, figure.highlight {
   @extend %vertical-rhythm;
-
-  .highlighter-rouge & {
-    background: $code-background-color;
+  border: 1px solid $border-color-01;
+  border-radius: 3px;
+  pre { margin: 0 }
+  table, tbody, th, tr, td {
+    margin: 0;
+    padding: 0;
+    border: 0
   }
+}
+
+figure.highlight {
+  & > pre { padding: 5px 0 0 }
+  td.gutter { border-right: 1px solid $border-color-01 }
+  td.code { width: 100% }
+}
+
+code.highlighter-rouge {
+  padding: 1px 5px;
+  font-size: 14px;
+  border: 1px solid $border-color-01;
+  border-radius: 3px;
 }
 
 

--- a/_sass/minima/skins/auto.scss
+++ b/_sass/minima/skins/auto.scss
@@ -19,7 +19,7 @@ $lm-site-title-color:      $lm-brand-color-dark !default;
 $lm-heading-color:         #111111 !default;
 $lm-text-color:            $lm-brand-color-dark !default;
 $lm-background-color:      #fdfdfd !default;
-$lm-code-background-color: #eeeeff !default;
+$lm-code-background-color: #f6f8fa !default;
 
 $lm-link-base-color:       #2a7ae2 !default;
 $lm-link-visited-color:    darken($lm-link-base-color, 15%) !default;
@@ -41,65 +41,83 @@ $lm-table-border-color:    $lm-border-color-01 !default;
 
 @mixin lm-highlight {
   .highlight {
-    .c     { color: #998; font-style: italic } // Comment
-    .err   { color: #a61717; background-color: #e3d2d2 } // Error
-    .k     { font-weight: bold } // Keyword
-    .o     { font-weight: bold } // Operator
-    .cm    { color: #998; font-style: italic } // Comment.Multiline
-    .cp    { color: #999; font-weight: bold } // Comment.Preproc
-    .c1    { color: #998; font-style: italic } // Comment.Single
-    .cs    { color: #999; font-weight: bold; font-style: italic } // Comment.Special
-    .gd    { color: #000; background-color: #fdd } // Generic.Deleted
-    .gd .x { color: #000; background-color: #faa } // Generic.Deleted.Specific
-    .ge    { font-style: italic } // Generic.Emph
-    .gr    { color: #a00 } // Generic.Error
-    .gh    { color: #999 } // Generic.Heading
-    .gi    { color: #000; background-color: #dfd } // Generic.Inserted
-    .gi .x { color: #000; background-color: #afa } // Generic.Inserted.Specific
-    .go    { color: #888 } // Generic.Output
-    .gp    { color: #555 } // Generic.Prompt
+    .err   { color: #e3d2d2; background-color: #a61717 } // Error
+
+    %comment { color: #9c9996 }
+    %italics { font-style: italic }
+    .c     { @extend %comment }            // Comment
+    .cm    { @extend %comment }            // Comment.Multiline
+    .cp    { @extend %comment }            // Comment.Preproc
+    .c1    { @extend %comment }            // Comment.Single
+    .cs    { @extend %comment, %italics }  // Comment.Special
+
+    .gd    { color: #e25050 }    // Generic.Deleted
+    .gd .x { color: #e25050 }    // Generic.Deleted.Specific
+    .ge    { @extend %italics }  // Generic.Emph
+    .gh    { color: #999999 }    // Generic.Heading
+    .gi    { color: #3f993f }    // Generic.Inserted
+    .gi .x { color: #3f993f }    // Generic.Inserted.Specific
+    .go    { color: #888888 }    // Generic.Output
+    .gp    { color: #555555 }    // Generic.Prompt
+    .gr    { color: #aa0000 }    // Generic.Error
     .gs    { font-weight: bold } // Generic.Strong
-    .gu    { color: #aaa } // Generic.Subheading
-    .gt    { color: #a00 } // Generic.Traceback
-    .kc    { font-weight: bold } // Keyword.Constant
-    .kd    { font-weight: bold } // Keyword.Declaration
-    .kp    { font-weight: bold } // Keyword.Pseudo
-    .kr    { font-weight: bold } // Keyword.Reserved
-    .kt    { color: #458; font-weight: bold } // Keyword.Type
-    .m     { color: #099 } // Literal.Number
-    .s     { color: #d14 } // Literal.String
-    .na    { color: #008080 } // Name.Attribute
-    .nb    { color: #0086B3 } // Name.Builtin
-    .nc    { color: #458; font-weight: bold } // Name.Class
-    .no    { color: #008080 } // Name.Constant
-    .ni    { color: #800080 } // Name.Entity
-    .ne    { color: #900; font-weight: bold } // Name.Exception
-    .nf    { color: #900; font-weight: bold } // Name.Function
-    .nn    { color: #555 } // Name.Namespace
-    .nt    { color: #000080 } // Name.Tag
-    .nv    { color: #008080 } // Name.Variable
-    .ow    { font-weight: bold } // Operator.Word
-    .w     { color: #bbb } // Text.Whitespace
-    .mf    { color: #099 } // Literal.Number.Float
-    .mh    { color: #099 } // Literal.Number.Hex
-    .mi    { color: #099 } // Literal.Number.Integer
-    .mo    { color: #099 } // Literal.Number.Oct
-    .sb    { color: #d14 } // Literal.String.Backtick
-    .sc    { color: #d14 } // Literal.String.Char
-    .sd    { color: #d14 } // Literal.String.Doc
-    .s2    { color: #d14 } // Literal.String.Double
-    .se    { color: #d14 } // Literal.String.Escape
-    .sh    { color: #d14 } // Literal.String.Heredoc
-    .si    { color: #d14 } // Literal.String.Interpol
-    .sx    { color: #d14 } // Literal.String.Other
-    .sr    { color: #009926 } // Literal.String.Regex
-    .s1    { color: #d14 } // Literal.String.Single
-    .ss    { color: #990073 } // Literal.String.Symbol
-    .bp    { color: #999 } // Name.Builtin.Pseudo
-    .vc    { color: #008080 } // Name.Variable.Class
-    .vg    { color: #008080 } // Name.Variable.Global
-    .vi    { color: #008080 } // Name.Variable.Instance
-    .il    { color: #099 } // Literal.Number.Integer.Long
+    .gt    { color: #aa0000 }    // Generic.Traceback
+    .gu    { color: #aaaaaa }    // Generic.Subheading
+
+    %keyword { color: #cf222e }
+    .k     { @extend %keyword }  // Keyword
+    .kc    { @extend %keyword }  // Keyword.Constant
+    .kd    { @extend %keyword }  // Keyword.Declaration
+    .kp    { @extend %keyword }  // Keyword.Pseudo
+    .kr    { @extend %keyword }  // Keyword.Reserved
+    .kt    { color: #445588 }    // Keyword.Type
+
+    %constant { color: #097e39 }
+    %variable { color: #752a75 }
+    .n     { color: #111111 }
+    .na    { @extend %constant }  // Name.Attribute
+    .nb    { @extend %keyword }   // Name.Builtin
+    .bp    { color: #999999 }     // Name.Builtin.Pseudo
+    .nc    { @extend %constant }  // Name.Class
+    .ne    { color: #990000 }     // Name.Exception
+    .nf    { color: #2c7d74 }     // Name.Function
+    .ni    { @extend %constant }  // Name.Entity
+    .nn    { @extend %constant }  // Name.Namespace
+    .no    { color: #a61154 }     // Name.Constant
+    .nt    { color: #b81e63 }     // Name.Tag
+    .nv    { @extend %variable }  // Name.Variable
+    .vc    { @extend %variable }  // Name.Variable.Class
+    .vg    { @extend %variable }  // Name.Variable.Global
+    .vi    { @extend %variable }  // Name.Variable.Instance
+
+    .o     { color: #0842a0 }  // Operator
+    .ow    { color: #0842a0 }  // Operator.Word
+
+    %numeric { color: #005a99 }
+    .m     { @extend %numeric }  // Literal.Number
+    .mf    { @extend %numeric }  // Literal.Number.Float
+    .mh    { @extend %numeric }  // Literal.Number.Hex
+    .mi    { @extend %numeric }  // Literal.Number.Integer
+    .il    { @extend %numeric }  // Literal.Number.Integer.Long
+    .mo    { @extend %numeric }  // Literal.Number.Oct
+
+    %string { color: #914d08 }
+    .s     { @extend %string }  // Literal.String
+    .s1    { @extend %string }  // Literal.String.Single
+    .s2    { @extend %string }  // Literal.String.Double
+    .sb    { @extend %string }  // Literal.String.Backtick
+    .sc    { @extend %string }  // Literal.String.Char
+    .sd    { @extend %string }  // Literal.String.Doc
+    .se    { @extend %string }  // Literal.String.Escape
+    .sh    { @extend %string }  // Literal.String.Heredoc
+    .si    { @extend %string }  // Literal.String.Interpol
+    .sr    { color: #009926 }   // Literal.String.Regex
+    .ss    { color: #0842a0 }   // Literal.String.Symbol
+    .sx    { @extend %string }  // Literal.String.Other
+
+    .w     { color: #bbbbbb }  // Text.Whitespace
+
+    .lineno, .gl { @extend %comment }  // Line Number
   }
 }
 
@@ -109,14 +127,14 @@ $lm-table-border-color:    $lm-border-color-01 !default;
 
 $dm-brand-color:           #999999 !default;
 $dm-brand-color-light:     lighten($dm-brand-color, 5%) !default;
-$dm-brand-color-dark:      darken($dm-brand-color, 39%) !default;
+$dm-brand-color-dark:      darken($dm-brand-color, 43%) !default;
 
 $dm-site-title-color:      $dm-brand-color-light !default;
 
 $dm-heading-color:         #bbbbbb !default;
 $dm-text-color:            darken($dm-heading-color, 15%) !default;
 $dm-background-color:      #181818 !default;
-$dm-code-background-color: #212121 !default;
+$dm-code-background-color: #222222 !default;
 
 $dm-link-base-color:       #79b8ff !default;
 $dm-link-visited-color:    $dm-link-base-color !default;
@@ -142,65 +160,83 @@ $dm-table-border-color:    $dm-border-color-01 !default;
 
 @mixin dm-highlight {
   .highlight {
-    .c     { color: #545454; font-style: italic } // Comment
-    .err   { color: #f07178; background-color: #e3d2d2 } // Error
-    .k     { color: #89DDFF; font-weight: bold } // Keyword
-    .o     { font-weight: bold } // Operator
-    .cm    { color: #545454; font-style: italic } // Comment.Multiline
-    .cp    { color: #545454; font-weight: bold } // Comment.Preproc
-    .c1    { color: #545454; font-style: italic } // Comment.Single
-    .cs    { color: #545454; font-weight: bold; font-style: italic } // Comment.Special
-    .gd    { color: #000; background-color: #fdd } // Generic.Deleted
-    .gd .x { color: #000; background-color: #faa } // Generic.Deleted.Specific
-    .ge    { font-style: italic } // Generic.Emph
-    .gr    { color: #f07178 } // Generic.Error
-    .gh    { color: #999 } // Generic.Heading
-    .gi    { color: #000; background-color: #dfd } // Generic.Inserted
-    .gi .x { color: #000; background-color: #afa } // Generic.Inserted.Specific
-    .go    { color: #888 } // Generic.Output
-    .gp    { color: #555 } // Generic.Prompt
+    .err   { color: #e3d2d2; background-color: #8c2121 } // Error
+
+    %comment { color: #8a8a8a }
+    %italics { font-style: italic }
+    .c     { @extend %comment }            // Comment
+    .c1    { @extend %comment }            // Comment.Single
+    .cm    { @extend %comment }            // Comment.Multiline
+    .cp    { @extend %comment }            // Comment.Preproc
+    .cs    { @extend %comment, %italics }  // Comment.Special
+
+    .gd    { color: #d85a5a }    // Generic.Deleted
+    .gd .x { color: #d85a5a }    // Generic.Deleted.Specific
+    .ge    { @extend %italics }  // Generic.Emph
+    .gh    { color: #999999 }    // Generic.Heading
+    .gi    { color: #4ec64e }    // Generic.Inserted
+    .gi .x { color: #4ec64e }    // Generic.Inserted.Specific
+    .go    { color: #888888 }    // Generic.Output
+    .gp    { color: #555555 }    // Generic.Prompt
+    .gr    { color: #f07178 }    // Generic.Error
     .gs    { font-weight: bold } // Generic.Strong
-    .gu    { color: #aaa } // Generic.Subheading
-    .gt    { color: #f07178 } // Generic.Traceback
-    .kc    { font-weight: bold } // Keyword.Constant
-    .kd    { font-weight: bold } // Keyword.Declaration
-    .kp    { font-weight: bold } // Keyword.Pseudo
-    .kr    { font-weight: bold } // Keyword.Reserved
-    .kt    { color: #FFCB6B; font-weight: bold } // Keyword.Type
-    .m     { color: #F78C6C } // Literal.Number
-    .s     { color: #C3E88D } // Literal.String
-    .na    { color: #008080 } // Name.Attribute
-    .nb    { color: #EEFFFF } // Name.Builtin
-    .nc    { color: #FFCB6B; font-weight: bold } // Name.Class
-    .no    { color: #008080 } // Name.Constant
-    .ni    { color: #800080 } // Name.Entity
-    .ne    { color: #900; font-weight: bold } // Name.Exception
-    .nf    { color: #82AAFF; font-weight: bold } // Name.Function
-    .nn    { color: #555 } // Name.Namespace
-    .nt    { color: #FFCB6B } // Name.Tag
-    .nv    { color: #EEFFFF } // Name.Variable
-    .ow    { font-weight: bold } // Operator.Word
-    .w     { color: #EEFFFF } // Text.Whitespace
-    .mf    { color: #F78C6C } // Literal.Number.Float
-    .mh    { color: #F78C6C } // Literal.Number.Hex
-    .mi    { color: #F78C6C } // Literal.Number.Integer
-    .mo    { color: #F78C6C } // Literal.Number.Oct
-    .sb    { color: #C3E88D } // Literal.String.Backtick
-    .sc    { color: #C3E88D } // Literal.String.Char
-    .sd    { color: #C3E88D } // Literal.String.Doc
-    .s2    { color: #C3E88D } // Literal.String.Double
-    .se    { color: #EEFFFF } // Literal.String.Escape
-    .sh    { color: #C3E88D } // Literal.String.Heredoc
-    .si    { color: #C3E88D } // Literal.String.Interpol
-    .sx    { color: #C3E88D } // Literal.String.Other
-    .sr    { color: #C3E88D } // Literal.String.Regex
-    .s1    { color: #C3E88D } // Literal.String.Single
-    .ss    { color: #C3E88D } // Literal.String.Symbol
-    .bp    { color: #999 } // Name.Builtin.Pseudo
-    .vc    { color: #FFCB6B } // Name.Variable.Class
-    .vg    { color: #EEFFFF } // Name.Variable.Global
-    .vi    { color: #EEFFFF } // Name.Variable.Instance
-    .il    { color: #F78C6C } // Literal.Number.Integer.Long
+    .gt    { color: #f07178 }    // Generic.Traceback
+    .gu    { color: #aaaaaa }    // Generic.Subheading
+
+    %keyword { color: #d85a7b }
+    .k     { @extend %keyword }  // Keyword
+    .kc    { @extend %keyword }  // Keyword.Constant
+    .kd    { @extend %keyword }  // Keyword.Declaration
+    .kp    { @extend %keyword }  // Keyword.Pseudo
+    .kr    { @extend %keyword }  // Keyword.Reserved
+    .kt    { color: #ffcb6b }    // Keyword.Type
+
+    %constant { color: #11a69f }
+    %variable { color: #9680b1 }
+    .n     { color: #c7d1d8 }
+    .na    { @extend %constant }  // Name.Attribute
+    .nb    { @extend %keyword }   // Name.Builtin
+    .bp    { color: #999999 }     // Name.Builtin.Pseudo
+    .nc    { @extend %constant }  // Name.Class
+    .ne    { color: #990000 }     // Name.Exception
+    .nf    { color: #5ab780 }     // Name.Function
+    .ni    { @extend %constant }  // Name.Entity
+    .nn    { @extend %constant }  // Name.Namespace
+    .no    { color: #9d99e6 }     // Name.Constant
+    .nt    { color: #de3581 }     // Name.Tag
+    .nv    { @extend %variable }  // Name.Variable
+    .vc    { @extend %variable }  // Name.Variable.Class
+    .vg    { @extend %variable }  // Name.Variable.Global
+    .vi    { @extend %variable }  // Name.Variable.Instance
+
+    .o     { color: #bcd890 }  // Operator
+    .ow    { color: #bcd890 }  // Operator.Word
+
+    %numeric { color: #9d99e6 }
+    .m     { @extend %numeric }  // Literal.Number
+    .mf    { @extend %numeric }  // Literal.Number.Float
+    .mh    { @extend %numeric }  // Literal.Number.Hex
+    .mi    { @extend %numeric }  // Literal.Number.Integer
+    .il    { @extend %numeric }  // Literal.Number.Integer.Long
+    .mo    { @extend %numeric }  // Literal.Number.Oct
+
+    %string { color: #baa94a }
+    .s     { @extend %string }  // Literal.String
+    .s1    { @extend %string }  // Literal.String.Single
+    .s2    { @extend %string }  // Literal.String.Double
+    .sb    { @extend %string }  // Literal.String.Backtick
+    .sc    { @extend %string }  // Literal.String.Char
+    .sd    { @extend %string }  // Literal.String.Doc
+    .se    { @extend %string }  // Literal.String.Escape
+    .sh    { @extend %string }  // Literal.String.Heredoc
+    .si    { @extend %string }  // Literal.String.Interpol
+    .sr    { color: #009926 }   // Literal.String.Regex
+    .ss    { color: #3c90f5 }   // Literal.String.Symbol
+    .sx    { @extend %string }  // Literal.String.Other
+
+    .w     { color: #eeffff }  // Text.Whitespace
+
+    .lineno, .gl { @extend %comment }  // Line Number
   }
 }
 

--- a/_sass/minima/skins/solarized.scss
+++ b/_sass/minima/skins/solarized.scss
@@ -43,9 +43,11 @@ $sol-green:    #859900;  // 60 -20  65
 $sol-light-mix1:  mix($sol-base1, $sol-base3);
 $sol-light-mix2:  mix($sol-blue, $sol-base00);
 $sol-light-mix3:  mix($sol-base2, $sol-base3);
+$sol-light-mix4:  #e8e3d4; // custom mixture of `$sol-base1` and `$sol-base3`.
 $sol-dark-mix1:   mix($sol-base01, $sol-base03);
 $sol-dark-mix2:   mix($sol-blue, $sol-base0);
 $sol-dark-mix3:   mix($sol-base02, $sol-base03);
+$sol-dark-mix4:   #193843; // custom mixture of `$sol-base01` and `$sol-base03`.
 
 
 // Mode selection
@@ -59,6 +61,7 @@ $sol-mono01:   $sol-base01;
 $sol-mix1:     $sol-light-mix1;
 $sol-mix2:     $sol-light-mix2;
 $sol-mix3:     $sol-light-mix3;
+$sol-mix4:     $sol-light-mix4;
 
 @if $sol-is-dark {
   $sol-mono3:  $sol-base03;
@@ -69,6 +72,7 @@ $sol-mix3:     $sol-light-mix3;
   $sol-mix1:   $sol-dark-mix1;
   $sol-mix2:   $sol-dark-mix2;
   $sol-mix3:   $sol-dark-mix3;
+  $sol-mix4:   $sol-dark-mix4;
 }
 
 @if $sol-is-auto {
@@ -81,6 +85,7 @@ $sol-mix3:     $sol-light-mix3;
     --solarized-mix1:   #{$sol-light-mix1};
     --solarized-mix2:   #{$sol-light-mix2};
     --solarized-mix3:   #{$sol-light-mix3};
+    --solarized-mix4:   #{$sol-light-mix4};
   }
 
   @media (prefers-color-scheme: dark) {
@@ -93,6 +98,7 @@ $sol-mix3:     $sol-light-mix3;
       --solarized-mix1:   #{$sol-dark-mix1};
       --solarized-mix2:   #{$sol-dark-mix2};
       --solarized-mix3:   #{$sol-dark-mix3};
+      --solarized-mix4:   #{$sol-dark-mix4};
     }
   }
 
@@ -104,6 +110,7 @@ $sol-mix3:     $sol-light-mix3;
   $sol-mix1:   var(--solarized-mix1);
   $sol-mix2:   var(--solarized-mix2);
   $sol-mix3:   var(--solarized-mix3);
+  $sol-mix4:   var(--solarized-mix4);
 }
 
 
@@ -111,7 +118,7 @@ $sol-mix3:     $sol-light-mix3;
 // ----------------------
 
 $brand-color:           $sol-mono1 !default;
-$brand-color-light:     $sol-mix1 !default;
+$brand-color-light:     $sol-mix4 !default;
 $brand-color-dark:      $sol-mono00 !default;
 
 $site-title-color:      $sol-mono00 !default;
@@ -119,7 +126,7 @@ $site-title-color:      $sol-mono00 !default;
 $heading-color:         $sol-mono01 !default;
 $text-color:            $sol-mono00 !default;
 $background-color:      $sol-mono3 !default;
-$code-background-color: $sol-mono2 !default;
+$code-background-color: $sol-mix3 !default;
 
 $link-base-color:       $sol-blue !default;
 $link-visited-color:    $sol-mix2 !default;
@@ -140,63 +147,79 @@ $table-border-color:    $sol-mix1 !default;
 // --------------------------
 
 .highlight {
-  .c     { color: $sol-mono1; font-style: italic } // Comment
-  .err   { color: $sol-red } // Error
-  .k     { color: $sol-mono01; font-weight: bold } // Keyword
-  .o     { color: $sol-mono01; font-weight: bold } // Operator
-  .cm    { color: $sol-mono1; font-style: italic } // Comment.Multiline
-  .cp    { color: $sol-mono1; font-weight: bold } // Comment.Preproc
-  .c1    { color: $sol-mono1; font-style: italic } // Comment.Single
-  .cs    { color: $sol-mono1; font-weight: bold; font-style: italic } // Comment.Special
-  .gd    { color: $sol-red } // Generic.Deleted
-  .gd .x { color: $sol-red } // Generic.Deleted.Specific
-  .ge    { color: $sol-mono00; font-style: italic } // Generic.Emph
-  .gr    { color: $sol-red } // Generic.Error
-  .gh    { color: $sol-mono1 } // Generic.Heading
-  .gi    { color: $sol-green } // Generic.Inserted
-  .gi .x { color: $sol-green } // Generic.Inserted.Specific
-  .go    { color: $sol-mono00 } // Generic.Output
-  .gp    { color: $sol-mono00 } // Generic.Prompt
-  .gs    { color: $sol-mono01; font-weight: bold } // Generic.Strong
-  .gu    { color: $sol-mono1 } // Generic.Subheading
-  .gt    { color: $sol-red } // Generic.Traceback
-  .kc    { color: $sol-mono01; font-weight: bold } // Keyword.Constant
-  .kd    { color: $sol-mono01; font-weight: bold } // Keyword.Declaration
-  .kp    { color: $sol-mono01; font-weight: bold } // Keyword.Pseudo
-  .kr    { color: $sol-mono01; font-weight: bold } // Keyword.Reserved
-  .kt    { color: $sol-violet; font-weight: bold } // Keyword.Type
-  .m     { color: $sol-cyan } // Literal.Number
-  .s     { color: $sol-magenta } // Literal.String
-  .na    { color: $sol-cyan } // Name.Attribute
-  .nb    { color: $sol-blue } // Name.Builtin
-  .nc    { color: $sol-violet; font-weight: bold } // Name.Class
-  .no    { color: $sol-cyan } // Name.Constant
-  .ni    { color: $sol-violet } // Name.Entity
-  .ne    { color: $sol-violet; font-weight: bold } // Name.Exception
-  .nf    { color: $sol-blue; font-weight: bold } // Name.Function
-  .nn    { color: $sol-mono00 } // Name.Namespace
-  .nt    { color: $sol-blue } // Name.Tag
-  .nv    { color: $sol-cyan } // Name.Variable
-  .ow    { color: $sol-mono01; font-weight: bold } // Operator.Word
-  .w     { color: $sol-mono1 } // Text.Whitespace
-  .mf    { color: $sol-cyan } // Literal.Number.Float
-  .mh    { color: $sol-cyan } // Literal.Number.Hex
-  .mi    { color: $sol-cyan } // Literal.Number.Integer
-  .mo    { color: $sol-cyan } // Literal.Number.Oct
-  .sb    { color: $sol-magenta } // Literal.String.Backtick
-  .sc    { color: $sol-magenta } // Literal.String.Char
-  .sd    { color: $sol-magenta } // Literal.String.Doc
-  .s2    { color: $sol-magenta } // Literal.String.Double
-  .se    { color: $sol-magenta } // Literal.String.Escape
-  .sh    { color: $sol-magenta } // Literal.String.Heredoc
-  .si    { color: $sol-magenta } // Literal.String.Interpol
-  .sx    { color: $sol-magenta } // Literal.String.Other
-  .sr    { color: $sol-green } // Literal.String.Regex
-  .s1    { color: $sol-magenta } // Literal.String.Single
-  .ss    { color: $sol-magenta } // Literal.String.Symbol
-  .bp    { color: $sol-mono1 } // Name.Builtin.Pseudo
-  .vc    { color: $sol-cyan } // Name.Variable.Class
-  .vg    { color: $sol-cyan } // Name.Variable.Global
-  .vi    { color: $sol-cyan } // Name.Variable.Instance
-  .il    { color: $sol-cyan } // Literal.Number.Integer.Long
+  .err   { color: #fefeec; background-color: $sol-red } // Error
+
+  %comment { color: $sol-mono1 }
+  %italics { font-style: italic }
+  .c     { @extend %comment }            // Comment
+  .c1    { @extend %comment }            // Comment.Single
+  .cm    { @extend %comment }            // Comment.Multiline
+  .cp    { @extend %comment }            // Comment.Preproc
+  .cs    { @extend %comment, %italics }  // Comment.Special
+
+  .gd    { color: $sol-red }                        // Generic.Deleted
+  .gd .x { color: $sol-red }                        // Generic.Deleted.Specific
+  .ge    { color: $sol-mono00; @extend %italics }   // Generic.Emph
+  .gh    { color: $sol-mono1 }                      // Generic.Heading
+  .gi    { color: $sol-green }                      // Generic.Inserted
+  .gi .x { color: $sol-green }                      // Generic.Inserted.Specific
+  .go    { color: $sol-mono00 }                     // Generic.Output
+  .gp    { color: $sol-mono00 }                     // Generic.Prompt
+  .gr    { color: $sol-red }                        // Generic.Error
+  .gs    { color: $sol-mono01; font-weight: bold }  // Generic.Strong
+  .gt    { color: $sol-red }                        // Generic.Traceback
+  .gu    { color: $sol-mono1 }                      // Generic.Subheading
+
+  %keyword { color: $sol-orange }
+  .k     { @extend %keyword }    // Keyword
+  .kc    { @extend %keyword }    // Keyword.Constant
+  .kd    { @extend %keyword }    // Keyword.Declaration
+  .kp    { @extend %keyword }    // Keyword.Pseudo
+  .kr    { @extend %keyword }    // Keyword.Reserved
+  .kt    { color: $sol-violet }  // Keyword.Type
+
+  %variable { color: $sol-cyan }
+  .na    { color: $sol-cyan }    // Name.Attribute
+  .nb    { color: $sol-orange }  // Name.Builtin
+  .bp    { color: $sol-blue }    // Name.Builtin.Pseudo
+  .nc    { color: $sol-violet }  // Name.Class
+  .ne    { color: $sol-violet }  // Name.Exception
+  .nf    { color: $sol-blue }    // Name.Function
+  .ni    { color: $sol-violet }  // Name.Entity
+  .nn    { color: $sol-violet }  // Name.Namespace
+  .no    { color: $sol-violet }  // Name.Constant
+  .nt    { color: $sol-orange }  // Name.Tag
+  .nv    { @extend %variable }   // Name.Variable
+  .vc    { @extend %variable }   // Name.Variable.Class
+  .vg    { @extend %variable }   // Name.Variable.Global
+  .vi    { @extend %variable }   // Name.Variable.Instance
+
+  .o     { color: $sol-green }  // Operator
+  .ow    { color: $sol-green }  // Operator.Word
+
+  %numeric { color: $sol-violet }
+  .m     { @extend %numeric }  // Literal.Number
+  .mf    { @extend %numeric }  // Literal.Number.Float
+  .mh    { @extend %numeric }  // Literal.Number.Hex
+  .mi    { @extend %numeric }  // Literal.Number.Integer
+  .il    { @extend %numeric }  // Literal.Number.Integer.Long
+  .mo    { @extend %numeric }  // Literal.Number.Oct
+
+  %string { color: $sol-magenta }
+  .s     { @extend %string }      // Literal.String
+  .s1    { @extend %string }      // Literal.String.Single
+  .s2    { @extend %string }      // Literal.String.Double
+  .sb    { @extend %string }      // Literal.String.Backtick
+  .sc    { @extend %string }      // Literal.String.Char
+  .sd    { @extend %string }      // Literal.String.Doc
+  .se    { @extend %string }      // Literal.String.Escape
+  .sh    { @extend %string }      // Literal.String.Heredoc
+  .si    { @extend %string }      // Literal.String.Interpol
+  .sr    { color: $sol-green }    // Literal.String.Regex
+  .ss    { color: $sol-magenta }  // Literal.String.Symbol
+  .sx    { @extend %string }      // Literal.String.Other
+
+  .w     { color: $sol-mono1 }   // Text.Whitespace
+
+  .lineno, .gl { @extend %comment }  // Line Number
 }


### PR DESCRIPTION
The rendering of code snippets with syntax-highlighting have not been adapted to suit various languages across available skins. This pull request reimplements the style rules around both inline-code snippets and code-snippet blocks.