### PR TITLE
Toggle icons based on `#nav-trigger` state

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,7 +10,7 @@
       <nav class="site-nav">
         <input type="checkbox" id="nav-trigger" class="nav-trigger" />
         <label for="nav-trigger">
-          <span class="menu-icon fas fa-bars fa-lg"></span>
+          <span class="menu-icon"></span>
         </label>
 
         <div class="drawer-container">

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -49,6 +49,11 @@
     padding-top: 18px;
     text-align: center;
 
+    &::before {
+      font-family: "Font Awesome 6 Free";
+      font-weight: 900;
+    }
+
     > svg path {
       fill: $border-color-03;
     }
@@ -63,31 +68,46 @@
     cursor: pointer;
   }
 
-  #nav-trigger ~ .drawer-container {
-    position: absolute;
-    top: 47px;
-    right: -16px;
-    clear: both;
-    width: 0;
-    height: calc(100vh - 60px);
-    transition: width 1s;
-    overflow: hidden;
-    background-color: $background-color;
-    border-left: 1px solid;
-    border-left-color: transparent;
-    .drawer { opacity: 0 }
-  }
-
-  #nav-trigger:checked ~ .drawer-container {
-    width: 180px;
-    padding-bottom: 5px;
-    transition: width 1s;
-    overflow: auto;
-    border-left-color: $border-color-01;
-    .drawer {
-      padding: $spacing-unit * 0.5;
-      opacity: 1;
-      transition: opacity 2s;
+  #nav-trigger {
+    ~ label[for=nav-trigger] .menu-icon {
+      &::before {
+        content: "\f0c9";
+        font-size: 1.25em;
+      }
+    }
+    ~ .drawer-container {
+      position: absolute;
+      top: 47px;
+      right: -16px;
+      clear: both;
+      width: 0;
+      height: calc(100vh - 60px);
+      transition: width 0.5s;
+      overflow: hidden;
+      background-color: $background-color;
+      border-left: 1px solid;
+      border-left-color: transparent;
+      .drawer { opacity: 0 }
+    }
+    &:checked {
+    ~ label[for=nav-trigger] .menu-icon {
+      &::before {
+        content: "\f00d";
+        font-size: 1.5em;
+      }
+    }
+      ~ .drawer-container {
+        width: 180px;
+        padding-bottom: 5px;
+        transition: width 0.5s;
+        overflow: auto;
+        border-left-color: $border-color-01;
+        .drawer {
+          padding: $spacing-unit * 0.5;
+          opacity: 1;
+          transition: opacity 1.5s;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Instead of having the icon for `#nav-trigger` remain *the triple-bars* / *hamburger* regardless of having the mobile navigation displayed, toggle between the triple-bars and ✖️ based on the state of the trigger.