### PR TITLE
Adapt styles for GFM task-lists

### DIFF
--- a/_posts/2016-05-20-this-post-demonstrates-post-content-styles.md
+++ b/_posts/2016-05-20-this-post-demonstrates-post-content-styles.md
@@ -70,6 +70,14 @@ In arcu magna, aliquet vel pretium et, molestie et arcu. Mauris lobortis nulla e
 
 In arcu magna, aliquet vel pretium et, molestie et arcu. Mauris lobortis nulla et felis ullamcorper bibendum. Phasellus et hendrerit mauris.
 
+### Whaaat, a checklist??
+
+- [ ] Milk
+- [x] Cookies
+  - [x] Classic Choco-chip
+  - [x] Sourdough Choco-chip
+- [ ] Chee-ee-eeee-zzze!!!!
+
 ### Oh hai, an unordered list!!
 
 In arcu magna, aliquet vel pretium et, molestie et arcu. Mauris lobortis nulla et felis ullamcorper bibendum. Phasellus et hendrerit mauris.
@@ -78,6 +86,10 @@ In arcu magna, aliquet vel pretium et, molestie et arcu. Mauris lobortis nulla e
 - Second item, dawg
 - Third item, what what?!
 - Fourth item, fo sheezy my neezy
+- Fifth item, nested!
+  - So la ti do
+  - Ba-da-bing!
+  - Ba-da-boom!
 
 ### Oh hai, an ordered list!!
 
@@ -87,8 +99,10 @@ In arcu magna, aliquet vel pretium et, molestie et arcu. Mauris lobortis nulla e
 2. Second item, dawg
 3. Third item, what what?!
 4. Fourth item, fo sheezy my neezy
-
-
+5. Fifth item, nested!
+  - So la ti do
+  - Ba-da-bing!
+  - Ba-da-boom!
 
 ## Headings are cool! (h2)
 

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -388,6 +388,42 @@
 
 
 /**
+ * Task-lists
+ */
+
+.task-list {
+  margin-left: 0;
+  padding-left: $spacing-unit * 0.6;
+}
+
+.task-list-item {
+  list-style-type: none;
+  &-checkbox {
+    position: relative;
+    margin-right: $spacing-unit * 0.3;
+    margin-left: -$spacing-unit * 0.5;
+    appearance: none;
+    border: 8px solid $border-color-01;
+    vertical-align: text-top;
+    z-index: -1;
+    &::after {
+      position: absolute;
+      top: -8px;
+      left: -3px;
+      width: 4px;
+      height: 10px;
+      content: "";
+      border: solid transparent;
+      border-width: 0 2px 2px 0;
+      transform: rotate(45deg);
+    }
+    &:checked::after { border-color: $border-color-03 }
+  }
+}
+
+
+
+/**
  * Grid helpers
  */
 @media screen and (min-width: $on-large) {


### PR DESCRIPTION
- Override system-specific / browser-specific styling of `input type="checkbox"`
- Task-lists are rendered flush against `.wrapper` in contrast to (un-)ordered lists that have a left-margin.
- CSS is dependent on markup / class names rendered by kramdown extension `kramdown-parser-gfm`.

<br />

![classic](https://github.com/user-attachments/assets/32b3aca9-500d-4ca3-b8a2-43ea7905f89e)
![dark](https://github.com/user-attachments/assets/ae54d424-bff5-404d-b76b-27f73547c38d)
![sol_light](https://github.com/user-attachments/assets/d6928608-a997-4840-abd2-ea9e4c92717f)
![sol_dark](https://github.com/user-attachments/assets/468b3d09-eea4-4054-9a47-a27bae2c1521)


Resolves #881