### PR TITLE
Undo fixed header

### DIFF
--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -2,7 +2,7 @@
  * Site header
  */
 .site-header {
-  position: fixed;
+  position: relative;
   width: 100%;
   min-height: $spacing-unit * 1.865;
   line-height: $base-line-height * $base-font-size * 2.25;
@@ -232,9 +232,7 @@
  * Page content
  */
 .page-content {
-  padding-top: 60px + $spacing-unit;
-  padding-inline: 0;
-  padding-bottom: $spacing-unit;
+  padding: $spacing-unit 0;
   flex: 1 0 auto;
 }
 


### PR DESCRIPTION
Revert decision to have the `.site-header` fixed to top of viewport because of the following UX issue:
  - Fixed header creates confusion when user navigates to an anchor (especially when the anchor is not at start of the page) because the anchor (typically a heading element) gets hidden underneath the sticky-header.