### PR TITLE
Render link to feed as last item of social-links list

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,13 @@ where `title` corresponds to the link-title displayed when a visitor hovers mous
 Social platform icons are rendered using the latest version of Font Awesome Free webfonts sourced via remote CDN.
 The full list of available social icons can be found at https://fontawesome.com/search?ic=brands
 
+> [!NOTE]
+> The link to your site's main syndication feed is always rendered as the last item of the social-links list.<br />
+> You may opt to not have this link rendered at all by setting config **`minima.hide_site_feed_link`** to `true`:
+> ```yaml
+> minima:
+>   hide_site_feed_link: true  # `false` or `null` by default
+> ```
 
 ### Enabling Google Analytics
 

--- a/_config.yml
+++ b/_config.yml
@@ -84,3 +84,9 @@
 #     - title: Jekyll at X (formerly Twitter)
 #       icon: x-twitter
 #       url: "https://x.com/jekyllrb"
+#
+#   Hide syndication feed subscription link.
+#     RSS / Atom feed link is always rendered as the last item of social-links
+#     list. Set below key to `true` to not have the link to feed rendered as
+#     part of social-links list.
+#   hide_site_feed_link: false

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,17 +7,6 @@
 
     <div class="footer-col-wrapper">
       <div class="footer-col">
-        <p class="feed-subscribe">
-          <a href="{{ site.feed.path | default: 'feed.xml' | absolute_url }}">
-            <svg class="svg-icon orange">
-              <path d="M12.8 16C12.8 8.978 7.022 3.2 0 3.2V0c8.777 0 16 7.223 16 16h-3.2zM2.194
-                11.61c1.21 0 2.195.985 2.195 2.196 0 1.21-.99 2.194-2.2 2.194C.98 16 0 15.017 0
-                13.806c0-1.21.983-2.195 2.194-2.195zM10.606
-                16h-3.11c0-4.113-3.383-7.497-7.496-7.497v-3.11c5.818 0 10.606 4.79 10.606 10.607z"
-              />
-            </svg><span>Subscribe</span>
-          </a>
-        </p>
       {%- if site.author %}
         <ul class="contact-list">
           {% if site.author.name -%}

--- a/_includes/social.html
+++ b/_includes/social.html
@@ -6,4 +6,17 @@
     </a>
   </li>
 {%- endfor -%}
+{% unless site.minima.hide_site_feed_link %}
+  <li>
+    <a href="{{ site.feed.path | default: 'feed.xml' | absolute_url }}" target="_blank" title="Subscribe to syndication feed">
+      <svg class="svg-icon grey" viewbox="0 0 16 16">
+        <path d="M12.8 16C12.8 8.978 7.022 3.2 0 3.2V0c8.777 0 16 7.223 16 16h-3.2zM2.194
+          11.61c1.21 0 2.195.985 2.195 2.196 0 1.21-.99 2.194-2.2 2.194C.98 16 0 15.017 0
+          13.806c0-1.21.983-2.195 2.194-2.195zM10.606
+          16h-3.11c0-4.113-3.383-7.497-7.496-7.497v-3.11c5.818 0 10.606 4.79 10.606 10.607z"
+        />
+      </svg>
+    </a>
+  </li>
+{%- endunless %}
 </ul>


### PR DESCRIPTION
- Move `[RSS Icon] Subscribe` link to the *social-links-list* as the last item of the list.
- Configure whether to render icon with **`minima:hide_site_feed_link`** (`false` or `null` by default).

### Preview:

![social-links-w-rss](https://github.com/user-attachments/assets/d48df07e-8ffd-4522-961f-1aa141a997ca)
