### PR TITLE
Add styles to be in sync with Jekyll's `mark_lines` feature

### DIFF
--- a/_posts/2016-05-19-codeblocks-ahoy.md
+++ b/_posts/2016-05-19-codeblocks-ahoy.md
@@ -86,7 +86,43 @@ author:
   id: 75636474
 ```
 
+{% highlight html %}
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Hello World</title>
+  </head>
+  <body>
+    <p>Hello, World!</p>
+  </body>
+</html>
+{% endhighlight %}
+
+{% highlight html mark_lines="1 4 7" %}
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Hello World</title>
+  </head>
+  <body>
+    <p>Hello, World!</p>
+  </body>
+</html>
+{% endhighlight %}
+
 {% highlight html linenos %}
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Hello World</title>
+  </head>
+  <body>
+    <p>Hello, World!</p>
+  </body>
+</html>
+{% endhighlight %}
+
+{% highlight html linenos mark_lines="1 4 7" %}
 <html>
   <head>
     <meta charset="utf-8" />

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -196,7 +196,7 @@ div.highlight, figure.highlight {
 }
 
 figure.highlight {
-  & > pre { padding: 5px 0 0 }
+  table { margin: -8px -12px -14px }
   td.gutter { border-right: 1px solid $border-color-01 }
   td.code { width: 100% }
 }

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -193,6 +193,7 @@ div.highlight, figure.highlight {
     padding: 0;
     border: 0
   }
+  .lineno, .gl { text-align: right }
 }
 
 figure.highlight {

--- a/_sass/minima/skins/auto.scss
+++ b/_sass/minima/skins/auto.scss
@@ -112,6 +112,7 @@ $lm-table-border-color:    $lm-border-color-01 !default;
     .w     { color: #bbbbbb } // Text.Whitespace
 
     .lineno, .gl { color: #9c9996 } // Line Number
+    .hll   { background-color: #ffffcc } // Marked-lines
   }
 }
 
@@ -225,6 +226,7 @@ $dm-table-border-color:    $dm-border-color-01 !default;
     .w     { color: #eeffff } // Text.Whitespace
 
     .lineno, .gl { color: #8a8a8a } // Line Number
+    .hll   { background-color: #373730 } // Marked-lines
   }
 }
 

--- a/_sass/minima/skins/solarized.scss
+++ b/_sass/minima/skins/solarized.scss
@@ -74,6 +74,8 @@ $sol-mono1-dimmed: darken($sol-base1, 20%);
 $sol-link-color:   $sol-dark-blue;
 $sol-link-visited: $sol-dark-blue2;
 
+$sol-mark-line-bgcolor: #ffffcc;
+
 @if $sol-is-dark {
   $sol-mono3:  $sol-base03;
   $sol-mono2:  $sol-base02;
@@ -88,6 +90,8 @@ $sol-link-visited: $sol-dark-blue2;
   $sol-mono1-dimmed: lighten($sol-base01, 16%);
   $sol-link-color:   $sol-light-blue;
   $sol-link-visited: $sol-light-blue2;
+
+  $sol-mark-line-bgcolor: #153d41;
 }
 
 @if $sol-is-auto {
@@ -105,6 +109,8 @@ $sol-link-visited: $sol-dark-blue2;
     --solarized-mono1-dimmed: #{darken($sol-base1, 20%)};
     --solarized-link-color:   #{$sol-dark-blue};
     --solarized-link-visited: #{$sol-dark-blue2};
+
+    --solarized-mark-line-bg-color: #ffffcc;
   }
 
   @media (prefers-color-scheme: dark) {
@@ -122,6 +128,8 @@ $sol-link-visited: $sol-dark-blue2;
       --solarized-mono1-dimmed: #{lighten($sol-base01, 16%)};
       --solarized-link-color:   #{$sol-light-blue};
       --solarized-link-visited: #{$sol-light-blue2};
+
+      --solarized-mark-line-bg-color: #153d41;
     }
   }
 
@@ -138,6 +146,8 @@ $sol-link-visited: $sol-dark-blue2;
   $sol-mono1-dimmed: var(--solarized-mono1-dimmed);
   $sol-link-color:   var(--solarized-link-color);
   $sol-link-visited: var(--solarized-link-visited);
+
+  $sol-mark-line-bgcolor: var(--solarized-mark-line-bg-color);
 }
 
 
@@ -244,4 +254,5 @@ $table-border-color:    $sol-mix1 !default;
   .w     { color: $sol-mono1 } // Text.Whitespace
 
   .lineno, .gl { color: $sol-mono1 } // Line Number
+  .hll   { background-color: $sol-mark-line-bgcolor } // Marked-lines
 }

--- a/_sass/minima/skins/solarized.scss
+++ b/_sass/minima/skins/solarized.scss
@@ -91,7 +91,7 @@ $sol-mark-line-bgcolor: #ffffcc;
   $sol-link-color:   $sol-light-blue;
   $sol-link-visited: $sol-light-blue2;
 
-  $sol-mark-line-bgcolor: #153d41;
+  $sol-mark-line-bgcolor: #164145;
 }
 
 @if $sol-is-auto {
@@ -129,7 +129,7 @@ $sol-mark-line-bgcolor: #ffffcc;
       --solarized-link-color:   #{$sol-light-blue};
       --solarized-link-visited: #{$sol-light-blue2};
 
-      --solarized-mark-line-bg-color: #153d41;
+      --solarized-mark-line-bg-color: #164145;
     }
   }
 


### PR DESCRIPTION
Jekyll 4.4 added the ability to mark specific lines of a codeblock rendered via Liquid tag `{% highlight %}`. This pull request enhances Minima to render marked-lines in sync with existing skins.