### PR TITLE
Restore the functionality of Disqus

### DIFF
--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -1,4 +1,5 @@
 {% if site.disqus.shortname -%}
+  <div id="disqus_thread"></div>
   <script>
     var disqus_config = function () {
       this.page.url = '{{ page.url | absolute_url }}';


### PR DESCRIPTION
Addresses the issue discussed in https://github.com/jekyll/minima/pull/886.