### PR TITLE
Pins font awesome font to version 7 and use it in the stylesheets

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-<link id="fa-stylesheet" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@latest/css/all.min.css">
+<link id="fa-stylesheet" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@7.0.0/css/all.min.css">
 
 <footer class="site-footer h-card">
   <data class="u-url" value="{{ '/' | relative_url }}"></data>

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -70,7 +70,7 @@
       text-align: center;
 
       &::before {
-        font-family: "Font Awesome 6 Free";
+        font-family: "Font Awesome 7 Free";
         font-weight: 900;
       }
 


### PR DESCRIPTION
Proposed fix for [this issue](https://github.com/jekyll/minima/issues/907) where the font awesome icons are not rendering correctly