### PR TITLE
Align nav-items on small screen devices

### DIFF
--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -110,6 +110,7 @@
 
     .nav-item {
       display: block;
+      margin-right: $spacing-unit * 0.5;
       padding: 5px 0;
       color: $text-color;
       line-height: $base-line-height;


### PR DESCRIPTION
Adjusted right margin of last navigation item when on small devices so that all nav-items align.

| Before  | After |
| ------------- | ------------- |
| <img width="146" height="181" alt="image" src="https://github.com/user-attachments/assets/ac2689da-48cb-47b7-8214-0705c93285cb" />  | <img width="147" height="181" alt="image" src="https://github.com/user-attachments/assets/1dbec07f-8b46-44ff-9aef-697f2746a546" /> |

Fixes #904 