### PR TITLE
Add syntax highlighting for Keyword.Namespace

### DIFF
--- a/_sass/minima/skins/auto.scss
+++ b/_sass/minima/skins/auto.scss
@@ -64,6 +64,7 @@ $lm-table-border-color:    $lm-border-color-01 !default;
     .gu    { color: #aaaaaa } // Generic.Subheading
 
     .k     { color: #cf222e } // Keyword
+    .kn    { color: #cf222e } // Keyword.Namespace
     .kc    { color: #cf222e } // Keyword.Constant
     .kd    { color: #cf222e } // Keyword.Declaration
     .kp    { color: #cf222e } // Keyword.Pseudo
@@ -178,6 +179,7 @@ $dm-table-border-color:    $dm-border-color-01 !default;
     .gu    { color: #aaaaaa } // Generic.Subheading
 
     .k     { color: #d85a7b } // Keyword
+    .kn    { color: #d85a7b } // Keyword.Namespace
     .kc    { color: #d85a7b } // Keyword.Constant
     .kd    { color: #d85a7b } // Keyword.Declaration
     .kp    { color: #d85a7b } // Keyword.Pseudo

--- a/_sass/minima/skins/solarized.scss
+++ b/_sass/minima/skins/solarized.scss
@@ -207,6 +207,7 @@ $table-border-color:    $sol-mix1 !default;
   .gu    { color: $sol-mono1 } // Generic.Subheading
 
   .k     { color: $sol-orange } // Keyword
+  .kn    { color: $sol-orange } // Keyword.Namespace
   .kc    { color: $sol-orange } // Keyword.Constant
   .kd    { color: $sol-orange } // Keyword.Declaration
   .kp    { color: $sol-orange } // Keyword.Pseudo


### PR DESCRIPTION
Python import statements like the following are currently not highlighted:

```python
import pathlib
from pathlib import Path
```

Rouge does tag the `import` and `from` keywords correctly, but Minima doesn't apply any color to them.

Fixes #131.